### PR TITLE
Fixed GCC-7 Build on Linux due to bad #elif

### DIFF
--- a/platform/qt/MainWindow.cpp
+++ b/platform/qt/MainWindow.cpp
@@ -757,7 +757,7 @@ void MainWindow::readSettings()
     if( m_styleSelection == 1 ) CDarkStyle::assign();
 #ifdef Q_OS_MACX
     else ui->scrollArea->setVerticalScrollBarPolicy( Qt::ScrollBarAsNeeded );
-#elif Q_OS_LINUX
+#elif defined(Q_OS_LINUX)
     else
     {
         ui->dockWidgetEdit->setMinimumWidth( 240 );


### PR DESCRIPTION
As I was building on Linux recently, the build (`make -j31`) broke with this error message:

```cpp
MainWindow.cpp:760:17: error: #elif with no expression
 #elif Q_OS_LINUX
```

I tracked down the bug commit by commit:
* The last **working commit** was 6ab033903ac947e5399061855a7313553b49e2a4 .
* The first **broken commit** was 3f594a0573ab038131077c4dc55aa2661220e02f .

Luckily, the fix was easy enough. The line simply had to be substituted for:
```cpp
#elif defined(Q_OS_LINUX)
```

It builds just fine now!