### PR TITLE
lj92: Fix issues related to SSSS=16

### DIFF
--- a/src/mlv/liblj92/lj92.c
+++ b/src/mlv/liblj92/lj92.c
@@ -315,6 +315,9 @@ static int decode(ljp* self) {
 }
 
 static int receive(ljp* self,int ssss) {
+    if (ssss == 16) {
+        return 1 << 15;
+    }
     int i = 0;
     int v = 0;
     while (i != ssss) {
@@ -366,24 +369,29 @@ inline static int nextdiff(ljp* self) {
     cnt -= usedbits;
     int keepbitsmask = (1 << cnt)-1;
     b &= keepbitsmask;
-    while (cnt < t) {
-        next = *(u16*)&self->data[ix];
-        int one = next&0xFF;
-        int two = next>>8;
-        b = (b<<16)|(one<<8)|two;
-        cnt += 16;
-        ix += 2;
-        if (one==0xFF) {
-            b >>= 8;
-            cnt -= 8;
-        } else if (two==0xFF) ix++;
-    }
-    cnt -= t;
-    int diff = b >> cnt;
-    int vt = 1<<(t-1);
-    if (diff < vt) {
-        vt = (-1 << t) + 1;
-        diff += vt;
+    int diff;
+    if (t == 16) {
+        diff = 1 << 15;
+    } else {
+        while (cnt < t) {
+            next = *(u16*)&self->data[ix];
+            int one = next&0xFF;
+            int two = next>>8;
+            b = (b<<16)|(one<<8)|two;
+            cnt += 16;
+            ix += 2;
+            if (one==0xFF) {
+                b >>= 8;
+                cnt -= 8;
+            } else if (two==0xFF) ix++;
+        }
+        cnt -= t;
+        diff = b >> cnt;
+        int vt = 1<<(t-1);
+        if (diff < vt) {
+            vt = (-1 << t) + 1;
+            diff += vt;
+        }
     }
     keepbitsmask = (1 << cnt)-1;
     self->b = b & keepbitsmask;
@@ -1068,7 +1076,6 @@ int writeBody(lje* self) {
         int huffcode = self->huffsym[ssss];
         int huffenc = self->huffenc[huffcode];
         int huffbits = self->huffbits[huffcode];
-        bitcount += huffbits + ssss;
 
         int vt = ssss>0?(1<<(ssss-1)):0;
         //printf("%d %d %d %d\n",rows[1][col],Px,diff,Px+diff);
@@ -1099,7 +1106,10 @@ int writeBody(lje* self) {
             }
         }
         // Write the rest of the bits for the value
-
+        if (ssss == 16) {
+            // Diff values (always -32678) for SSSS=16 are encoded with 0 bits
+            ssss = 0;
+        }
         while (ssss>0) {
             int usebits = ssss>nextbits?nextbits:ssss;
             // Add top usebits from huffval to next usebits of nextbits
@@ -1206,5 +1216,4 @@ int lj92_encode(uint16_t* image, int width, int height, int bitdepth,
 
     return ret;
 }
-
 

--- a/src/mlv/liblj92/lj92.c
+++ b/src/mlv/liblj92/lj92.c
@@ -768,6 +768,7 @@ int frequencyScan(lje* self) {
             Px = rows[0][col] + ((rows[1][col-1] - rows[0][col-1])>>1);
         diff = rows[1][col] - Px;
         diff = diff%65536;
+        diff = (int16_t)diff;
         int ssss = 32 - __builtin_clz(abs(diff));
         if (diff==0) ssss=0;
         self->hist[ssss]++;
@@ -1058,6 +1059,7 @@ int writeBody(lje* self) {
             Px = rows[0][col] + ((rows[1][col-1] - rows[0][col-1])>>1);
         diff = rows[1][col] - Px;
         diff = diff%65536;
+        diff = (int16_t)diff;
         int ssss = 32 - __builtin_clz(abs(diff));
         if (diff==0) ssss=0;
         //printf("%d %d %d %d %d\n",col,row,Px,diff,ssss);


### PR DESCRIPTION
Hi!

I've been working on my own lossless JPEG encoder and found it useful to use the decoder in lj92 for debugging. (I don't know any details about the MLV format.) First I thought I had some bug in my encoder, but it turns out there are a few problems with the implementation of lj92 instead:
1. `SSSS=16` should only be used for `diff=-32678` as specified in the [spec](https://www.w3.org/Graphics/JPEG/itu-t81.pdf) in _H.1.2.2_.
2. `diff` values for `SSSS=16` should be encoded with zero bits (and decoded with zero bits just returning 32678 as the diff).

This pull-request fixes the first issue. It should be safe to merge with a couple of added benefits:
* Reduced size of the encoded buffer.
* Reduced risk of running into issues with decoders compliant with the spec. (From now on `SSSS=16` will not be used used for any bitdepths lower than 15.)

I don't know how you should handle the second issue. I can create a pull request fixing that as well, but I guess you need to keep both implementations and use some version tag in the metadata for controlling which decoder to use. (Adobe fixed the same issue for DNG 1.1, see _Compatibility Issue 2_ in _Appendix A_ of the [spec](https://www.adobe.com/content/dam/acom/en/products/photoshop/pdfs/dng_spec_1.4.0.0.pdf).)