### PR TITLE
Fix musl compile error linux

### DIFF
--- a/src/mlv/video_mlv.c
+++ b/src/mlv/video_mlv.c
@@ -9,11 +9,9 @@
 #include <inttypes.h>
 #include "camid/camera_id.h"
 
+#include <unistd.h>
 #if defined(__linux)
 #include <alloca.h>
-extern int usleep (__useconds_t __useconds);
-#else
-#include <unistd.h>
 #endif
 
 #include "video_mlv.h"


### PR DESCRIPTION
Why avoid including unistd.h? Why does else exist at all?