### PR TITLE
Suppress uninit data usage warning in strcpy()

### DIFF
--- a/src/mlv/video_mlv.c
+++ b/src/mlv/video_mlv.c
@@ -500,7 +500,7 @@ void getMlvProcessedFrame8(mlvObject_t * video, uint64_t frameIndex, uint8_t * o
 mlvObject_t * initMlvObjectWithClip(char * mlvPath, int preview, int * err, char * error_message)
 {
     mlvObject_t * video = initMlvObject();
-    char error_message_tmp[256];
+    char error_message_tmp[256] = {0};
     int err_tmp =  openMlvClip(video, mlvPath, preview, error_message_tmp);
     if (err != NULL) *err = err_tmp;
     if (error_message != NULL) strcpy(error_message, error_message_tmp);


### PR DESCRIPTION
Valgrind complains about the uninitialised buffer within strcpy() code.  This could be a false positive, but it could be real - it was quicker to ensure it's initialised than check.