### PR TITLE
Add element to ssshist

### DIFF
--- a/src/mlv/liblj92/lj92.c
+++ b/src/mlv/liblj92/lj92.c
@@ -49,7 +49,7 @@ typedef struct _ljp {
     int skiplen; // Skip this many values after each row
     u16* linearize; // Linearization table
     int linlen;
-    int sssshist[16];
+    int sssshist[17];
 
     // Huffman table - only one supported, and probably needed
 #ifdef SLOW_HUFF


### PR DESCRIPTION
sssshist stores a histogram of how often each ssss value is used.  There are 16 of them, from 1-16.  Though 0 is unused, it's more convenient to index the elements by ssss so, rather than subtract one before indexing, we will make the array larger by one element.

This fixes #266