### PR TITLE
Qt-6.5.1 and C++17 fix [Linux]

### DIFF
--- a/platform/qt/MoveToTrash.cpp
+++ b/platform/qt/MoveToTrash.cpp
@@ -76,9 +76,9 @@ int MoveToTrash( QString fileName )
     QFile infoFile(trashInfoPath+fileInfo.completeBaseName()+"."+fileNum+fileInfo.completeSuffix()+".trashinfo");     //filename+extension+.trashinfo //  create file information file in /.local/share/Trash/info/ folder
     infoFile.open(QIODevice::ReadWrite);
     QTextStream stream(&infoFile);         // for write data on open file
-    stream<<"[Trash Info]"<<endl;
-    stream<<"Path="+QString(QUrl::toPercentEncoding(fileInfo.absoluteFilePath(),"~_-./"))<<endl;     // convert path string in percentage decoding scheme string
-    stream<<"DeletionDate="+currentTime.toString("yyyy-MM-dd")+"T"+currentTime.toString("hh:mm:ss")<<endl;      // get date and time format YYYY-MM-DDThh:mm:ss
+    stream<<"[Trash Info]\n";
+    stream<<"Path="+QString(QUrl::toPercentEncoding(fileInfo.absoluteFilePath(),"~_-./")) + "\n";     // convert path string in percentage decoding scheme string
+    stream<<"DeletionDate="+currentTime.toString("yyyy-MM-dd")+"T"+currentTime.toString("hh:mm:ss") + "\n";      // get date and time format YYYY-MM-DDThh:mm:ss
     infoFile.close();
     // create info file format of trash file----- END
 


### PR DESCRIPTION
After removing "-std=c++11" from QMAKE_CXXFLAGS, to allow linking Qt6 on my Gentoo Linux system, g++ 13.1.1 (which defaults to C++17) complains about "endl" not being defined. Including <iostream> and changing it to "std::endl" fixes the definition problem, but is not accepted by Qt6's "<<" operator.

In the end, I fixed it by replacing "endl" with good ol' "\n" instead.