### PR TITLE
If the pipe can not be closed fine, inform user about export failure.

### DIFF
--- a/platform/qt/MainWindow.cpp
+++ b/platform/qt/MainWindow.cpp
@@ -2160,7 +2160,10 @@ void MainWindow::startExportPipe(QString fileName)
                 if( m_exportAbortPressed ) break;
             }
             //Close pipe
-            pclose( pPipeStab );
+            if( pclose( pPipeStab ) != 0 )
+            {
+                QMessageBox::critical( this, tr( "File export failed" ), tr( "FFmpeg closed unexpectedly during stabilization.\n\nFile %1 was not exported." ).arg( fileName ) );
+            }
             free( imgBufferScaled );
             free( imgBuffer );
         }
@@ -2699,7 +2702,10 @@ void MainWindow::startExportPipe(QString fileName)
             if( m_exportAbortPressed ) break;
         }
         //Close pipe
-        pclose( pPipe );
+        if( pclose( pPipe ) != 0 )
+        {
+            QMessageBox::critical( this, tr( "File export failed" ), tr( "FFmpeg closed unexpectedly during export.\n\nFile %1 was not exported." ).arg( fileName ) );
+        }
         free( imgBufferScaled );
         free( imgBuffer );
     }

--- a/platform/qt/MainWindow.cpp
+++ b/platform/qt/MainWindow.cpp
@@ -2713,7 +2713,7 @@ void MainWindow::startExportPipe(QString fileName)
         free( imgBufferScaled );
         free( imgBuffer );
     }
-	}
+    }
 
     //Delete wav file
     QFile *file = new QFile( wavFileName );

--- a/platform/qt/MainWindow.cpp
+++ b/platform/qt/MainWindow.cpp
@@ -1711,6 +1711,7 @@ void MainWindow::writeSettings()
 //Start Export via Pipe
 void MainWindow::startExportPipe(QString fileName)
 {
+    bool staberr = false;
     //ffmpeg existing?
     {
 #if defined __linux__ && !defined APP_IMAGE
@@ -2162,7 +2163,8 @@ void MainWindow::startExportPipe(QString fileName)
             //Close pipe
             if( pclose( pPipeStab ) != 0 )
             {
-                QMessageBox::critical( this, tr( "File export failed" ), tr( "FFmpeg closed unexpectedly during stabilization.\n\nFile %1 was not exported." ).arg( fileName ) );
+                staberr = true;
+                QMessageBox::critical( this, tr( "File export failed" ), tr( "FFmpeg closed unexpectedly during stabilization.\n\nFile %1 was not exported completely." ).arg( fileName ) );
             }
             free( imgBufferScaled );
             free( imgBuffer );
@@ -2612,6 +2614,8 @@ void MainWindow::startExportPipe(QString fileName)
         program.insert( program.indexOf( "-c:v" ), pass3 );
     }
 
+	if( ( m_exportQueue.first()->vidStabEnabled() && staberr == false ) || !m_exportQueue.first()->vidStabEnabled() )
+    {
     //Try to open pipe
     FILE *pPipe;
     //qDebug() << "Call ffmpeg:" << program;
@@ -2704,11 +2708,12 @@ void MainWindow::startExportPipe(QString fileName)
         //Close pipe
         if( pclose( pPipe ) != 0 )
         {
-            QMessageBox::critical( this, tr( "File export failed" ), tr( "FFmpeg closed unexpectedly during export.\n\nFile %1 was not exported." ).arg( fileName ) );
+            QMessageBox::critical( this, tr( "File export failed" ), tr( "FFmpeg closed unexpectedly during export.\n\nFile %1 was not exported completely." ).arg( fileName ) );
         }
         free( imgBufferScaled );
         free( imgBuffer );
     }
+	}
 
     //Delete wav file
     QFile *file = new QFile( wavFileName );


### PR DESCRIPTION
I missed to see a messagebox like this while exporting files. However there is one con: If you batch export several files, and one fails, the messagebox will wait for user input, so it pauses the batch export.