### PR TITLE
Dual ISO single frame computation speedup

### DIFF
--- a/src/mlv/llrawproc/dualiso.c
+++ b/src/mlv/llrawproc/dualiso.c
@@ -1028,7 +1028,6 @@ static inline void amaze_interpolate(struct raw_info raw_info, uint32_t * raw_bu
     }
 
     //multithreaded debayer
-
     int threads = omp_get_num_procs();
     int startchunk_y[threads];
     int endchunk_y[threads];
@@ -1073,9 +1072,6 @@ static inline void amaze_interpolate(struct raw_info raw_info, uint32_t * raw_bu
             w, (endchunk_y[thread] - startchunk_y[thread]),
             0,
             0 };
-
-        /* Amaze arguments */
-       // amaze_arguments[thread] = (amazeinfo_t) { rawData, red, green, blue, 0, 0, w, h, 0, 0 };
 
         /* Create pthread! */
         pthread_create( &thread_id[thread], NULL, (void *)&demosaic, (void *)&amaze_arguments[thread] );


### PR DESCRIPTION
Parallelize Dual ISO's demosaic + parallelize interpolation.
Dual ISO computation for a single frame takes ~28% less time (tested on 2 of my PCs, depending on CPU speed and core number).

I tested full rendering (+ DNG rendering) with dozens of MLV videos I made, and the result is the exact same, but faster. If someone is interested in testing the changes themselves, it would be great.

Fixes in part #86 (I will send another PR in a different area that speeds DNG rendering further soon, if testing goes well)