### PR TITLE
Allow the settings panel to grow wider and increase waveform graph resolution

### DIFF
--- a/platform/qt/MainWindow.ui
+++ b/platform/qt/MainWindow.ui
@@ -335,7 +335,7 @@
    </property>
    <property name="maximumSize">
     <size>
-     <width>500</width>
+     <width>1000</width>
      <height>524287</height>
     </size>
    </property>

--- a/platform/qt/WaveFormMonitor.cpp
+++ b/platform/qt/WaveFormMonitor.cpp
@@ -10,7 +10,7 @@
 //The higher this values, the higher the performance
 //The lower this values, the higher the quality
 //We skip only columns, because it is really ugly if not...
-#define MERGE 8 //must be 2^x
+#define MERGE 4 //must be 2^x
 
 //Constructor
 WaveFormMonitor::WaveFormMonitor( uint16_t width )


### PR DESCRIPTION
On ultra wide screen monitors, it's very helpful to have a bigger wave forms graph with better resolution 