### PR TITLE
Add headless batch mode with receipt support and resume capability

### DIFF
--- a/platform/qt/MLVApp.pro
+++ b/platform/qt/MLVApp.pro
@@ -244,7 +244,8 @@ SOURCES += \
     ../../src/debayer/ahdOld.c \
     ../../src/batch/BatchContext.cpp \
     ../../src/batch/BatchPrompts.cpp \
-    ../../src/batch/BatchRunner.cpp
+    ../../src/batch/BatchRunner.cpp \
+    ../../src/batch/BatchLogger.cpp
 
 INCLUDEPATH += ../../src/librtprocess/src/include/
 INCLUDEPATH += $$PWD/../../src
@@ -376,7 +377,8 @@ HEADERS += MainWindow.h \
     ../../src/batch/BatchTypes.h \
     ../../src/batch/BatchContext.h \
     ../../src/batch/BatchPrompts.h \
-    ../../src/batch/BatchRunner.h
+    ../../src/batch/BatchRunner.h \
+    ../../src/batch/BatchLogger.h
 
 macx: HEADERS += \
     ../cocoa/avf_lib/avencoder.h \

--- a/platform/qt/MLVApp.pro
+++ b/platform/qt/MLVApp.pro
@@ -245,7 +245,8 @@ SOURCES += \
     ../../src/batch/BatchContext.cpp \
     ../../src/batch/BatchPrompts.cpp \
     ../../src/batch/BatchRunner.cpp \
-    ../../src/batch/BatchLogger.cpp
+    ../../src/batch/BatchLogger.cpp \
+    ../../src/batch/ReceiptLoader.cpp
 
 INCLUDEPATH += ../../src/librtprocess/src/include/
 INCLUDEPATH += $$PWD/../../src
@@ -378,7 +379,8 @@ HEADERS += MainWindow.h \
     ../../src/batch/BatchContext.h \
     ../../src/batch/BatchPrompts.h \
     ../../src/batch/BatchRunner.h \
-    ../../src/batch/BatchLogger.h
+    ../../src/batch/BatchLogger.h \
+    ../../src/batch/ReceiptLoader.h
 
 macx: HEADERS += \
     ../cocoa/avf_lib/avencoder.h \

--- a/platform/qt/MLVApp.pro
+++ b/platform/qt/MLVApp.pro
@@ -241,7 +241,9 @@ SOURCES += \
     ../../src/librtprocess/src/postprocess/hilite_recon.cc \
     ../../src/librtprocess/src/preprocess/CA_correct.cc \
     ../../src/librtprocess/src/include/librtprocesswrapper.cpp \
-    ../../src/debayer/ahdOld.c
+    ../../src/debayer/ahdOld.c \
+    ../../src/batch/BatchContext.cpp \
+    ../../src/batch/BatchPrompts.cpp
 
 INCLUDEPATH += ../../src/librtprocess/src/include/
 
@@ -368,7 +370,10 @@ HEADERS += MainWindow.h \
     ../../src/librtprocess/src/include/xtranshelper.h \
     ../../src/librtprocess/src/include/librtprocesswrapper.h \
     ../../src/librtprocess/src/include/sleef.h \
-    ../../src/librtprocess/src/include/sleefsseavx.h
+    ../../src/librtprocess/src/include/sleefsseavx.h \
+    ../../src/batch/BatchTypes.h \
+    ../../src/batch/BatchContext.h \
+    ../../src/batch/BatchPrompts.h
 
 macx: HEADERS += \
     ../cocoa/avf_lib/avencoder.h \

--- a/platform/qt/MLVApp.pro
+++ b/platform/qt/MLVApp.pro
@@ -243,9 +243,11 @@ SOURCES += \
     ../../src/librtprocess/src/include/librtprocesswrapper.cpp \
     ../../src/debayer/ahdOld.c \
     ../../src/batch/BatchContext.cpp \
-    ../../src/batch/BatchPrompts.cpp
+    ../../src/batch/BatchPrompts.cpp \
+    ../../src/batch/BatchRunner.cpp
 
 INCLUDEPATH += ../../src/librtprocess/src/include/
+INCLUDEPATH += $$PWD/../../src
 
 macx: SOURCES += ../cocoa/avf_lib/avf_lib.m
 
@@ -373,7 +375,8 @@ HEADERS += MainWindow.h \
     ../../src/librtprocess/src/include/sleefsseavx.h \
     ../../src/batch/BatchTypes.h \
     ../../src/batch/BatchContext.h \
-    ../../src/batch/BatchPrompts.h
+    ../../src/batch/BatchPrompts.h \
+    ../../src/batch/BatchRunner.h
 
 macx: HEADERS += \
     ../cocoa/avf_lib/avencoder.h \

--- a/platform/qt/MLVApp.pro
+++ b/platform/qt/MLVApp.pro
@@ -246,7 +246,8 @@ SOURCES += \
     ../../src/batch/BatchPrompts.cpp \
     ../../src/batch/BatchRunner.cpp \
     ../../src/batch/BatchLogger.cpp \
-    ../../src/batch/ReceiptLoader.cpp
+    ../../src/batch/ReceiptLoader.cpp \
+    ../../src/batch/ReceiptApplier.cpp
 
 INCLUDEPATH += ../../src/librtprocess/src/include/
 INCLUDEPATH += $$PWD/../../src
@@ -380,7 +381,8 @@ HEADERS += MainWindow.h \
     ../../src/batch/BatchPrompts.h \
     ../../src/batch/BatchRunner.h \
     ../../src/batch/BatchLogger.h \
-    ../../src/batch/ReceiptLoader.h
+    ../../src/batch/ReceiptLoader.h \
+    ../../src/batch/ReceiptApplier.h
 
 macx: HEADERS += \
     ../cocoa/avf_lib/avencoder.h \

--- a/platform/qt/MainWindow.cpp
+++ b/platform/qt/MainWindow.cpp
@@ -62,7 +62,7 @@
 #include "RenameDialog.h"
 #include "batch/BatchContext.h"
 #include "batch/BatchPrompts.h"
-#include <QTextStream>
+#include "batch/BatchLogger.h"
 #include <QElapsedTimer>
 
 /* spaceTag argument options: ffmpeg color space tag number compliant */
@@ -2765,7 +2765,6 @@ ProcessResult MainWindow::exportCdngSequence(
     ProcessResult result;
     QElapsedTimer timer;
     timer.start();
-    QTextStream out(stdout);
     bool verbose = BatchContext::isVerbose();
 
     /* --- Prepare mlvObject for raw export --- */
@@ -2931,11 +2930,10 @@ ProcessResult MainWindow::exportCdngSequence(
         }
         else if( BatchContext::isBatchMode() && verbose )
         {
-            out << QStringLiteral("[BATCH] FRAME %1 %2/%3\n")
+            BatchLogger::out(QStringLiteral("[BATCH] FRAME %1 %2/%3\n")
                        .arg( clipBaseName )
                        .arg( result.framesExported + result.framesSkipped )
-                       .arg( totalFrames );
-            out.flush();
+                       .arg( totalFrames ));
         }
 
         /* Let event loop breathe */

--- a/platform/qt/MainWindow.cpp
+++ b/platform/qt/MainWindow.cpp
@@ -60,6 +60,10 @@
 #include "FocusPixelMapManager.h"
 #include "StatusFpmDialog.h"
 #include "RenameDialog.h"
+#include "batch/BatchContext.h"
+#include "batch/BatchPrompts.h"
+#include <QTextStream>
+#include <QElapsedTimer>
 
 /* spaceTag argument options: ffmpeg color space tag number compliant */
 #define SPACETAG_REC709   1   /* rec709 color space */
@@ -109,6 +113,10 @@ MainWindow::MainWindow(int &argc, char **argv, QWidget *parent) :
     QSurfaceFormat::setDefaultFormat(format);
 
     ui->setupUi(this);
+
+    /* Wire the "Abort batch export" button in BatchPrompts QMessageBox */
+    BatchPrompts::setAbortBatchCallback([this]{ exportAbort(); });
+
     setAcceptDrops(true);
     qApp->installEventFilter( this );
 
@@ -2737,191 +2745,259 @@ void MainWindow::startExportPipe(QString fileName)
     emit exportReady();
 }
 
-//CDNG output
+/* Static CDNG export helper — callable from GUI and batch mode.
+ * All error decisions go through BatchPrompts.
+ * ProgressCallback is for progress UI and abort-polling only. */
+ProcessResult MainWindow::exportCdngSequence(
+    mlvObject_t *mlvObject,
+    const QString &outDir,
+    const QString &clipBaseName,
+    int codecProfile,
+    int codecOption,
+    uint32_t cutIn,
+    uint32_t cutOut,
+    double stretchX,
+    double stretchY,
+    bool audioExport,
+    bool rawFixEnabled,
+    ProgressCallback progressCallback)
+{
+    ProcessResult result;
+    QElapsedTimer timer;
+    timer.start();
+    QTextStream out(stdout);
+    bool verbose = BatchContext::isVerbose();
+
+    /* --- Prepare mlvObject for raw export --- */
+    setMlvAlwaysUseAmaze( mlvObject );
+    llrpResetFpmStatus(mlvObject);
+    llrpResetBpmStatus(mlvObject);
+    llrpComputeStripesOn(mlvObject);
+    mlvObject->current_cached_frame_active = 0;
+    if( rawFixEnabled ) mlvObject->llrawproc->fix_raw = 1;
+
+    /* --- Build subfolder path and naming prefix --- */
+    QString pathName = outDir;
+    if( codecOption == CODEC_CNDG_DEFAULT )
+    {
+        pathName = pathName + QStringLiteral("/%1").arg( clipBaseName );
+    }
+    else
+    {
+        pathName = pathName + QStringLiteral("/%1_1_%2-%3-%4_0001_C0000")
+            .arg( clipBaseName )
+            .arg( getMlvTmYear( mlvObject ), 2, 10, QChar('0') )
+            .arg( getMlvTmMonth( mlvObject ), 2, 10, QChar('0') )
+            .arg( getMlvTmDay( mlvObject ), 2, 10, QChar('0') );
+    }
+
+    /* Create output subfolder */
+    QDir dir;
+    if( !dir.mkpath( pathName ) )
+    {
+        result.success = false;
+        result.errorMessage = QStringLiteral("Failed to create output folder: %1").arg( pathName );
+        result.elapsedSeconds = timer.elapsed() / 1000.0;
+        return result;
+    }
+
+    /* --- Export WAV audio if requested --- */
+    if( doesMlvHaveAudio( mlvObject ) && audioExport )
+    {
+        QString wavFileName = pathName;
+        if( codecOption == CODEC_CNDG_DEFAULT )
+            wavFileName = wavFileName + QStringLiteral("/%1.wav").arg( clipBaseName );
+        else
+            wavFileName = wavFileName + QStringLiteral("/%1_1_%2-%3-%4_0001_C0000.wav")
+                .arg( clipBaseName )
+                .arg( getMlvTmYear( mlvObject ), 2, 10, QChar('0') )
+                .arg( getMlvTmMonth( mlvObject ), 2, 10, QChar('0') )
+                .arg( getMlvTmDay( mlvObject ), 2, 10, QChar('0') );
+#ifdef Q_OS_UNIX
+        writeMlvAudioToWaveCut( mlvObject, wavFileName.toUtf8().data(), cutIn, cutOut );
+#else
+        writeMlvAudioToWaveCut( mlvObject, wavFileName.toLatin1().data(), cutIn, cutOut );
+#endif
+    }
+
+    /* --- Compute pixel aspect ratio from stretch factors --- */
+    int32_t picAR[4] = { 0 };
+    if( stretchX == STRETCH_H_125 )      { picAR[0] = 5; picAR[1] = 4; }
+    else if( stretchX == STRETCH_H_133 ) { picAR[0] = 4; picAR[1] = 3; }
+    else if( stretchX == STRETCH_H_150 ) { picAR[0] = 3; picAR[1] = 2; }
+    else if( stretchX == STRETCH_H_167 ) { picAR[0] = 5; picAR[1] = 3; }
+    else if( stretchX == STRETCH_H_175 ) { picAR[0] = 7; picAR[1] = 4; }
+    else if( stretchX == STRETCH_H_180 ) { picAR[0] = 9; picAR[1] = 5; }
+    else if( stretchX == STRETCH_H_200 ) { picAR[0] = 2; picAR[1] = 1; }
+    else                                 { picAR[0] = 1; picAR[1] = 1; }
+
+    if( stretchY == STRETCH_V_167 )      { picAR[2] = 5; picAR[3] = 3; }
+    else if( stretchY == STRETCH_V_300 ) { picAR[2] = 3; picAR[3] = 1; }
+    else if( stretchY == STRETCH_V_033 ) { picAR[2] = 1; picAR[3] = 1; picAR[0] *= 3; }
+    else                                 { picAR[2] = 1; picAR[3] = 1; }
+
+    /* --- Init DNG struct --- */
+    double fps = getMlvFramerate( mlvObject );
+    dngObject_t *cinemaDng = initDngObject( mlvObject, codecProfile - 6, fps, picAR );
+
+    /* Render one frame for raw correction init */
+    uint32_t frameSize = getMlvWidth( mlvObject ) * getMlvHeight( mlvObject ) * 3;
+    uint16_t *imgBuffer = (uint16_t *)malloc( frameSize * sizeof( uint16_t ) );
+    getMlvProcessedFrame16( mlvObject, 0, imgBuffer, QThread::idealThreadCount() );
+    free( imgBuffer );
+
+    /* --- Frame export loop (cutIn/cutOut are 1-based) --- */
+    int totalFrames = cutOut - cutIn + 1;
+    bool aborted = false;
+    for( uint32_t frame = cutIn - 1; frame < cutOut; frame++ )
+    {
+        /* Build frame filename */
+        QString dngName;
+        if( codecOption == CODEC_CNDG_DEFAULT )
+        {
+            dngName = QStringLiteral("%1_%2.dng")
+                .arg( clipBaseName )
+                .arg( getMlvFrameNumber( mlvObject, frame ), 6, 10, QChar('0') );
+        }
+        else
+        {
+            dngName = QStringLiteral("%1_1_%2-%3-%4_0001_C0000_%5.dng")
+                .arg( clipBaseName )
+                .arg( getMlvTmYear( mlvObject ), 2, 10, QChar('0') )
+                .arg( getMlvTmMonth( mlvObject ), 2, 10, QChar('0') )
+                .arg( getMlvTmDay( mlvObject ), 2, 10, QChar('0') )
+                .arg( getMlvFrameNumber( mlvObject, frame ), 6, 10, QChar('0') );
+        }
+
+        QString filePathNr = pathName + QStringLiteral("/") + dngName;
+
+        /* Save cDNG frame */
+        QString properties_fn = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+#ifdef Q_OS_UNIX
+        properties_fn.append("/mlv-dng-params.txt");
+        int saveErr = saveDngFrame( mlvObject, cinemaDng, frame,
+                                    filePathNr.toUtf8().data(),
+                                    properties_fn.toUtf8().data() );
+#else
+        properties_fn.append("\\mlv-dng-params.txt");
+        int saveErr = saveDngFrame( mlvObject, cinemaDng, frame,
+                                    filePathNr.toLatin1().data(),
+                                    properties_fn.toLatin1().data() );
+#endif
+        if( saveErr )
+        {
+            /* Frame save failed — BatchPrompts decides skip-or-abort */
+            if( BatchPrompts::shouldSkipFrame( clipBaseName, frame, filePathNr ) )
+            {
+                result.framesSkipped++;
+                continue;
+            }
+            else
+            {
+                result.success = false;
+                result.errorMessage = QStringLiteral("saveDngFrame failed for frame %1 (%2)")
+                    .arg( frame ).arg( filePathNr );
+                aborted = true;
+                break;
+            }
+        }
+        else
+        {
+            result.framesExported++;
+        }
+
+        /* Check disk space */
+        QStorageInfo disk( QFileInfo( filePathNr ).path() );
+        if( 20 > disk.bytesAvailable() / 1024 / 1024 )
+        {
+            if( !BatchPrompts::shouldContinue( clipBaseName,
+                    QStringLiteral("Disk full — less than 20 MB remaining") ) )
+            {
+                result.success = false;
+                result.errorMessage = QStringLiteral("Disk full during export");
+                aborted = true;
+                break;
+            }
+        }
+
+        /* Progress callback — called once per frame after write/skip */
+        if( progressCallback )
+        {
+            if( !progressCallback( result.framesExported + result.framesSkipped, totalFrames ) )
+            {
+                aborted = true;
+                break;
+            }
+        }
+        else if( BatchContext::isBatchMode() && verbose )
+        {
+            out << QStringLiteral("[BATCH] FRAME %1 %2/%3\n")
+                       .arg( clipBaseName )
+                       .arg( result.framesExported + result.framesSkipped )
+                       .arg( totalFrames );
+            out.flush();
+        }
+
+        /* Let event loop breathe */
+        qApp->processEvents();
+    }
+
+    /* Free DNG struct */
+    freeDngObject( cinemaDng );
+
+    if( !aborted )
+    {
+        result.success = ( result.framesSkipped == 0 )
+                         || BatchContext::skipErrors();
+    }
+    result.elapsedSeconds = timer.elapsed() / 1000.0;
+    return result;
+}
+
+//CDNG output — thin wrapper that delegates to the static helper
 void MainWindow::startExportCdng(QString fileName)
 {
     //Disable GUI drawing
     m_dontDraw = true;
 
-    // we always get amaze frames for exporting
-    setMlvAlwaysUseAmaze( m_pMlvObject );
-    llrpResetFpmStatus(m_pMlvObject);
-    llrpResetBpmStatus(m_pMlvObject);
-    llrpComputeStripesOn(m_pMlvObject);
-    m_pMlvObject->current_cached_frame_active = 0;
-    //enable low level raw fixes (if wanted)
-    if( ui->checkBoxRawFixEnable->isChecked() ) m_pMlvObject->llrawproc->fix_raw = 1;
-
-    //StatusDialog
-    m_pStatusDialog->ui->progressBar->setMaximum( m_exportQueue.first()->cutOut() - m_exportQueue.first()->cutIn() + 1 );
+    //StatusDialog — use this clip's frame count for progress bar and ETA
+    int clipFrames = m_exportQueue.first()->cutOut() - m_exportQueue.first()->cutIn() + 1;
+    m_pStatusDialog->ui->progressBar->setMaximum( clipFrames );
     m_pStatusDialog->ui->progressBar->setValue( 0 );
     m_pStatusDialog->open();
-    //Frames in the export queue?!
-    int totalFrames = 0;
-    for( int i = 0; i < m_exportQueue.size(); i++ )
-    {
-        totalFrames += m_exportQueue.at(i)->cutOut() - m_exportQueue.at(i)->cutIn() + 1;
-    }
 
-    //Create folders and build name schemes
+    //Extract parameters for the static helper
     QString pathName = QFileInfo( fileName ).path();
-    fileName = QFileInfo( fileName ).fileName();
-    fileName = fileName.left( fileName.indexOf( '.' ) );
+    QString clipBaseName = QFileInfo( fileName ).fileName();
+    clipBaseName = clipBaseName.left( clipBaseName.indexOf( '.' ) );
 
-    if( m_codecOption == CODEC_CNDG_DEFAULT ) pathName = pathName.append( "/%1" ).arg( fileName );
-    else pathName = pathName.append( "/%1_1_%2-%3-%4_0001_C0000" )
-            .arg( fileName )
-            .arg( getMlvTmYear( m_pMlvObject ), 2, 10, QChar('0') )
-            .arg( getMlvTmMonth( m_pMlvObject ), 2, 10, QChar('0') )
-            .arg( getMlvTmDay( m_pMlvObject ), 2, 10, QChar('0') );
+    uint32_t cutIn  = m_exportQueue.first()->cutIn();
+    uint32_t cutOut = m_exportQueue.first()->cutOut();
 
-    //qDebug() << pathName << fileName;
-    //Create folder
-    QDir dir;
-    dir.mkpath( pathName );
-
-    //Output WAVE
-    if( doesMlvHaveAudio( m_pMlvObject ) && m_audioExportEnabled )
+    /* GUI progress callback — updates StatusDialog, polls abort button */
+    ProgressCallback guiProgress = [this, clipFrames]
+        (int framesDone, int /*totalFrames*/) -> bool
     {
-        QString wavFileName = pathName;
-        if( m_codecOption == CODEC_CNDG_DEFAULT ) wavFileName = wavFileName.append( "/%1.wav" ).arg( fileName );
-        else wavFileName = wavFileName.append( "/%1_1_%2-%3-%4_0001_C0000.wav" )
-            .arg( fileName )
-            .arg( getMlvTmYear( m_pMlvObject ), 2, 10, QChar('0') )
-            .arg( getMlvTmMonth( m_pMlvObject ), 2, 10, QChar('0') )
-            .arg( getMlvTmDay( m_pMlvObject ), 2, 10, QChar('0') );
-        //qDebug() << wavFileName;
-#ifdef Q_OS_UNIX
-        writeMlvAudioToWaveCut( m_pMlvObject, wavFileName.toUtf8().data(), m_exportQueue.first()->cutIn(), m_exportQueue.first()->cutOut() );
-#else
-        writeMlvAudioToWaveCut( m_pMlvObject, wavFileName.toLatin1().data(), m_exportQueue.first()->cutIn(), m_exportQueue.first()->cutOut() );
-#endif
-    }
-
-    //Set aspect ratio of the picture
-    int32_t picAR[4] = { 0 };
-    //Set horizontal stretch
-    if( m_exportQueue.first()->stretchFactorX() == STRETCH_H_125 )
-    {
-        picAR[0] = 5; picAR[1] = 4;
-    }
-    else if( m_exportQueue.first()->stretchFactorX() == STRETCH_H_133 )
-    {
-        picAR[0] = 4; picAR[1] = 3;
-    }
-    else if( m_exportQueue.first()->stretchFactorX() == STRETCH_H_150 )
-    {
-        picAR[0] = 3; picAR[1] = 2;
-    }
-    else if( m_exportQueue.first()->stretchFactorX() == STRETCH_H_167 )
-    {
-        picAR[0] = 5; picAR[1] = 3;
-    }
-    else if( m_exportQueue.first()->stretchFactorX() == STRETCH_H_175 )
-    {
-        picAR[0] = 7; picAR[1] = 4;
-    }
-    else if( m_exportQueue.first()->stretchFactorX() == STRETCH_H_180 )
-    {
-        picAR[0] = 9; picAR[1] = 5;
-    }
-    else if( m_exportQueue.first()->stretchFactorX() == STRETCH_H_200 )
-    {
-        picAR[0] = 2; picAR[1] = 1;
-    }
-    else
-    {
-        picAR[0] = 1; picAR[1] = 1;
-    }
-    //Set vertical stretch
-    if(m_exportQueue.first()->stretchFactorY() == STRETCH_V_167)
-    {
-        picAR[2] = 5; picAR[3] = 3;
-    }
-    else if(m_exportQueue.first()->stretchFactorY() == STRETCH_V_300)
-    {
-        picAR[2] = 3; picAR[3] = 1;
-    }
-    else if(m_exportQueue.first()->stretchFactorY() == STRETCH_V_033)
-    {
-        picAR[2] = 1; picAR[3] = 1; picAR[0] *= 3; //Upscale only
-    }
-    else
-    {
-        picAR[2] = 1; picAR[3] = 1;
-    }
-
-    //Init DNG data struct
-    dngObject_t * cinemaDng = initDngObject( m_pMlvObject, m_codecProfile - 6, getFramerate(), picAR);
-
-    //Render one single frame for raw correction init
-    uint32_t frameSize = getMlvWidth( m_pMlvObject ) * getMlvHeight( m_pMlvObject ) * 3;
-    uint16_t * imgBuffer;
-    imgBuffer = ( uint16_t* )malloc( frameSize * sizeof( uint16_t ) );
-    getMlvProcessedFrame16( m_pMlvObject, 0, imgBuffer, QThread::idealThreadCount() );
-    free( imgBuffer );
-
-    //Output frames loop
-    for( uint32_t frame = m_exportQueue.first()->cutIn() - 1; frame < m_exportQueue.first()->cutOut(); frame++ )
-    {
-        QString dngName;
-        if( m_codecOption == CODEC_CNDG_DEFAULT ) dngName = dngName.append( "%1_%2.dng" )
-                                                                                .arg( fileName )
-                                                                                .arg( getMlvFrameNumber( m_pMlvObject, frame ), 6, 10, QChar('0') );
-        else dngName = dngName.append( "%1_1_%2-%3-%4_0001_C0000_%5.dng" )
-            .arg( fileName )
-            .arg( getMlvTmYear( m_pMlvObject ), 2, 10, QChar('0') )
-            .arg( getMlvTmMonth( m_pMlvObject ), 2, 10, QChar('0') )
-            .arg( getMlvTmDay( m_pMlvObject ), 2, 10, QChar('0') )
-            .arg( getMlvFrameNumber( m_pMlvObject, frame ), 6, 10, QChar('0') );
-
-        QString filePathNr = pathName;
-        filePathNr = filePathNr.append( "/" + dngName );
-
-        //Save cDNG frame
-#ifdef Q_OS_UNIX
-        QString properties_fn = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
-        properties_fn.append("/mlv-dng-params.txt");
-        if( saveDngFrame( m_pMlvObject, cinemaDng, frame, filePathNr.toUtf8().data(), properties_fn.toUtf8().data() ) )
-#else
-        QString properties_fn = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
-        properties_fn.append("\\mlv-dng-params.txt");
-        if( saveDngFrame( m_pMlvObject, cinemaDng, frame, filePathNr.toLatin1().data(), properties_fn.toLatin1().data() ) )
-#endif
-        {
-            m_pStatusDialog->close();
-            qApp->processEvents();
-            int ret = QMessageBox::critical( this,
-                                             tr( "MLV App - Export file error" ),
-                                             tr( "Could not save: %1\nHow do you like to proceed?" ).arg( dngName ),
-                                             tr( "Skip frame" ),
-                                             tr( "Abort current export" ),
-                                             tr( "Abort batch export" ),
-                                             0, 2 );
-            if( ret == 2 )
-            {
-                exportAbort();
-            }
-            if( ret > 0 )
-            {
-                break;
-            }
-        }
-
-        //Set Status
-        m_pStatusDialog->ui->progressBar->setValue( frame - ( m_exportQueue.first()->cutIn() - 1 ) + 1 );
+        m_pStatusDialog->ui->progressBar->setValue( framesDone );
         m_pStatusDialog->ui->progressBar->repaint();
-        m_pStatusDialog->drawTimeFromToDoFrames( totalFrames - frame + ( m_exportQueue.first()->cutIn() - 1 ) - 1 );
+        m_pStatusDialog->drawTimeFromToDoFrames( clipFrames - framesDone );
         qApp->processEvents();
+        return !m_exportAbortPressed;
+    };
 
-        //Check diskspace
-        checkDiskFull( filePathNr );
-        //Abort pressed? -> End the loop
-        if( m_exportAbortPressed ) break;
-    }
-
-    //Free DNG data struct
-    freeDngObject( cinemaDng );
+    exportCdngSequence(
+        m_pMlvObject,
+        pathName,
+        clipBaseName,
+        m_codecProfile,
+        m_codecOption,
+        cutIn,
+        cutOut,
+        m_exportQueue.first()->stretchFactorX(),
+        m_exportQueue.first()->stretchFactorY(),
+        m_audioExportEnabled,
+        ui->checkBoxRawFixEnable->isChecked(),
+        guiProgress );
 
     //Enable GUI drawing
     m_dontDraw = false;

--- a/platform/qt/MainWindow.h
+++ b/platform/qt/MainWindow.h
@@ -39,6 +39,8 @@
 #include "Scripting.h"
 #include "ReceiptCopyMaskDialog.h"
 #include "QRecentFilesMenu.h"
+#include "batch/BatchTypes.h"
+#include <functional>
 
 namespace Ui {
 class MainWindow;
@@ -51,6 +53,29 @@ class MainWindow : public QMainWindow
 public:
     explicit MainWindow(int &argc, char **argv, QWidget *parent = 0);
     ~MainWindow();
+
+    /* Progress-only callback for exportCdngSequence.
+     * framesDone:   frames completed so far (exported + skipped)
+     * totalFrames:  total frames to export
+     * Return true to continue, false to abort (e.g. user pressed abort). */
+    using ProgressCallback = std::function<bool(int framesDone, int totalFrames)>;
+
+    /* Static CDNG export helper — callable from both GUI and batch mode.
+     * Error decisions go through BatchPrompts directly.
+     * ProgressCallback is for progress updates and abort-polling only. */
+    static ProcessResult exportCdngSequence(
+        mlvObject_t *mlvObject,
+        const QString &outDir,
+        const QString &clipBaseName,
+        int codecProfile,
+        int codecOption,
+        uint32_t cutIn,
+        uint32_t cutOut,
+        double stretchX,
+        double stretchY,
+        bool audioExport,
+        bool rawFixEnabled,
+        ProgressCallback progressCallback = nullptr);
 
 protected:
     void timerEvent( QTimerEvent *t );

--- a/platform/qt/main.cpp
+++ b/platform/qt/main.cpp
@@ -9,6 +9,7 @@
 #include "MyApplication.h"
 #include "../../src/batch/BatchContext.h"
 #include "../../src/batch/BatchRunner.h"
+#include "../../src/batch/BatchLogger.h"
 
 #include <QCommandLineParser>
 #include <QTextStream>
@@ -28,12 +29,16 @@ static bool hasBatchFlag(int argc, char *argv[])
 
 static int runBatch(QCoreApplication &app)
 {
-    QTextStream out(stdout);
-
     QCommandLineParser parser;
     parser.setApplicationDescription(
         QStringLiteral("MLVApp batch mode — headless Cinema DNG export"));
-    parser.addHelpOption();
+
+    /* Do NOT call parser.addHelpOption() — on Windows/Qt it triggers a
+     * QMessageBox.  We handle -h/--help manually below. */
+    QCommandLineOption helpOpt(
+        QStringList() << QStringLiteral("h") << QStringLiteral("help"),
+        QStringLiteral("Show this help text and exit."));
+    parser.addOption(helpOpt);
 
     /* --batch is already consumed by hasBatchFlag(); add it here so
      * QCommandLineParser doesn't complain about an unknown option. */
@@ -72,18 +77,31 @@ static int runBatch(QCoreApplication &app)
 
     parser.process(app);
 
-    /* --input and --output are required in batch mode */
-    if (!parser.isSet(inputOpt) || !parser.isSet(outputOpt))
+    /* Init log file mirror as early as possible so that --help and
+     * missing-arg errors are captured in the log file too. */
+    QString logPath = parser.value(logOpt);
+    BatchLogger::init(logPath);
+
+    /* --help: print to stdout (+ log), exit 0.  No QMessageBox. */
+    if( parser.isSet(helpOpt) )
     {
-        out << QStringLiteral("[BATCH] ERROR: --input and --output are required.\n");
-        out.flush();
-        parser.showHelp(2); /* exits with code 2 (bad arguments) */
+        BatchLogger::out(parser.helpText() + QStringLiteral("\n"));
+        BatchLogger::shutdown();
+        return 0;
+    }
+
+    /* --input and --output are required in batch mode */
+    if( !parser.isSet(inputOpt) || !parser.isSet(outputOpt) )
+    {
+        BatchLogger::err(QStringLiteral("[BATCH] ERROR: --input and --output are required.\n\n"));
+        BatchLogger::err(parser.helpText() + QStringLiteral("\n"));
+        BatchLogger::shutdown();
+        return 2;
     }
 
     QString inputPath  = parser.value(inputOpt);
     QString outputPath = parser.value(outputOpt);
     bool skipErrors    = parser.isSet(skipErrorsOpt);
-    QString logPath    = parser.value(logOpt);
     bool verbose       = parser.isSet(verboseOpt);
 
     /* Store in BatchContext for global access */
@@ -92,7 +110,9 @@ static int runBatch(QCoreApplication &app)
     BatchContext::setVerbose(verbose);
     BatchContext::setLogPath(logPath);
 
-    return BatchRunner::run(inputPath, outputPath);
+    int exitCode = BatchRunner::run(inputPath, outputPath);
+    BatchLogger::shutdown();
+    return exitCode;
 }
 
 int main(int argc, char *argv[])

--- a/platform/qt/main.cpp
+++ b/platform/qt/main.cpp
@@ -75,6 +75,12 @@ static int runBatch(QCoreApplication &app)
         QStringLiteral("Enable detailed per-frame logging."));
     parser.addOption(verboseOpt);
 
+    QCommandLineOption receiptOpt(
+        QStringList() << QStringLiteral("r") << QStringLiteral("receipt"),
+        QStringLiteral("Apply .marxml receipt settings to export."),
+        QStringLiteral("file"));
+    parser.addOption(receiptOpt);
+
     parser.process(app);
 
     /* Init log file mirror as early as possible so that --help and
@@ -99,16 +105,18 @@ static int runBatch(QCoreApplication &app)
         return 2;
     }
 
-    QString inputPath  = parser.value(inputOpt);
-    QString outputPath = parser.value(outputOpt);
-    bool skipErrors    = parser.isSet(skipErrorsOpt);
-    bool verbose       = parser.isSet(verboseOpt);
+    QString inputPath   = parser.value(inputOpt);
+    QString outputPath  = parser.value(outputOpt);
+    bool skipErrors     = parser.isSet(skipErrorsOpt);
+    bool verbose        = parser.isSet(verboseOpt);
+    QString receiptPath = parser.value(receiptOpt);
 
     /* Store in BatchContext for global access */
     BatchContext::setBatchMode(true);
     BatchContext::setSkipErrors(skipErrors);
     BatchContext::setVerbose(verbose);
     BatchContext::setLogPath(logPath);
+    BatchContext::setReceiptPath(receiptPath);
 
     int exitCode = BatchRunner::run(inputPath, outputPath);
     BatchLogger::shutdown();

--- a/platform/qt/main.cpp
+++ b/platform/qt/main.cpp
@@ -81,6 +81,11 @@ static int runBatch(QCoreApplication &app)
         QStringLiteral("file"));
     parser.addOption(receiptOpt);
 
+    QCommandLineOption defaultReceiptOpt(
+        QStringLiteral("default-receipt"),
+        QStringLiteral("Use the GUI-configured default receipt."));
+    parser.addOption(defaultReceiptOpt);
+
     parser.process(app);
 
     /* Init log file mirror as early as possible so that --help and
@@ -109,7 +114,8 @@ static int runBatch(QCoreApplication &app)
     QString outputPath  = parser.value(outputOpt);
     bool skipErrors     = parser.isSet(skipErrorsOpt);
     bool verbose        = parser.isSet(verboseOpt);
-    QString receiptPath = parser.value(receiptOpt);
+    QString receiptPath     = parser.value(receiptOpt);
+    bool useDefaultReceipt  = parser.isSet(defaultReceiptOpt);
 
     /* Store in BatchContext for global access */
     BatchContext::setBatchMode(true);
@@ -117,6 +123,7 @@ static int runBatch(QCoreApplication &app)
     BatchContext::setVerbose(verbose);
     BatchContext::setLogPath(logPath);
     BatchContext::setReceiptPath(receiptPath);
+    BatchContext::setUseDefaultReceipt(useDefaultReceipt);
 
     int exitCode = BatchRunner::run(inputPath, outputPath);
     BatchLogger::shutdown();

--- a/platform/qt/main.cpp
+++ b/platform/qt/main.cpp
@@ -8,6 +8,7 @@
 #include "MainWindow.h"
 #include "MyApplication.h"
 #include "../../src/batch/BatchContext.h"
+#include "../../src/batch/BatchRunner.h"
 
 #include <QCommandLineParser>
 #include <QTextStream>
@@ -91,16 +92,7 @@ static int runBatch(QCoreApplication &app)
     BatchContext::setVerbose(verbose);
     BatchContext::setLogPath(logPath);
 
-    out << QStringLiteral("[BATCH] START input=%1 output=%2 skip-errors=%3\n")
-               .arg(inputPath,
-                    outputPath,
-                    skipErrors ? QStringLiteral("true")
-                               : QStringLiteral("false"));
-    out.flush();
-
-    /* TODO Phase 5: wire BatchRunner here.
-     * For now, stub — print and exit 0. */
-    return 0;
+    return BatchRunner::run(inputPath, outputPath);
 }
 
 int main(int argc, char *argv[])

--- a/platform/qt/main.cpp
+++ b/platform/qt/main.cpp
@@ -7,14 +7,123 @@
 
 #include "MainWindow.h"
 #include "MyApplication.h"
+#include "../../src/batch/BatchContext.h"
+
+#include <QCommandLineParser>
+#include <QTextStream>
+#include <cstring>
+
+/* Raw argv scan for "--batch" BEFORE QApplication is constructed.
+ * QCommandLineParser needs QApplication, but we need to know the
+ * mode early to skip MainWindow creation entirely in batch mode. */
+static bool hasBatchFlag(int argc, char *argv[])
+{
+    for (int i = 1; i < argc; ++i)
+    {
+        if (std::strcmp(argv[i], "--batch") == 0) return true;
+    }
+    return false;
+}
+
+static int runBatch(QCoreApplication &app)
+{
+    QTextStream out(stdout);
+
+    QCommandLineParser parser;
+    parser.setApplicationDescription(
+        QStringLiteral("MLVApp batch mode — headless Cinema DNG export"));
+    parser.addHelpOption();
+
+    /* --batch is already consumed by hasBatchFlag(); add it here so
+     * QCommandLineParser doesn't complain about an unknown option. */
+    QCommandLineOption batchOpt(
+        QStringLiteral("batch"),
+        QStringLiteral("Run in headless batch export mode."));
+    parser.addOption(batchOpt);
+
+    QCommandLineOption inputOpt(
+        QStringList() << QStringLiteral("i") << QStringLiteral("input"),
+        QStringLiteral("Input MLV file or folder path."),
+        QStringLiteral("path"));
+    parser.addOption(inputOpt);
+
+    QCommandLineOption outputOpt(
+        QStringList() << QStringLiteral("o") << QStringLiteral("output"),
+        QStringLiteral("Output directory for exported DNG sequences."),
+        QStringLiteral("path"));
+    parser.addOption(outputOpt);
+
+    QCommandLineOption skipErrorsOpt(
+        QStringLiteral("skip-errors"),
+        QStringLiteral("Skip corrupt frames instead of aborting."));
+    parser.addOption(skipErrorsOpt);
+
+    QCommandLineOption logOpt(
+        QStringLiteral("log"),
+        QStringLiteral("Mirror log output to file."),
+        QStringLiteral("file"));
+    parser.addOption(logOpt);
+
+    QCommandLineOption verboseOpt(
+        QStringLiteral("verbose"),
+        QStringLiteral("Enable detailed per-frame logging."));
+    parser.addOption(verboseOpt);
+
+    parser.process(app);
+
+    /* --input and --output are required in batch mode */
+    if (!parser.isSet(inputOpt) || !parser.isSet(outputOpt))
+    {
+        out << QStringLiteral("[BATCH] ERROR: --input and --output are required.\n");
+        out.flush();
+        parser.showHelp(2); /* exits with code 2 (bad arguments) */
+    }
+
+    QString inputPath  = parser.value(inputOpt);
+    QString outputPath = parser.value(outputOpt);
+    bool skipErrors    = parser.isSet(skipErrorsOpt);
+    QString logPath    = parser.value(logOpt);
+    bool verbose       = parser.isSet(verboseOpt);
+
+    /* Store in BatchContext for global access */
+    BatchContext::setBatchMode(true);
+    BatchContext::setSkipErrors(skipErrors);
+    BatchContext::setVerbose(verbose);
+    BatchContext::setLogPath(logPath);
+
+    out << QStringLiteral("[BATCH] START input=%1 output=%2 skip-errors=%3\n")
+               .arg(inputPath,
+                    outputPath,
+                    skipErrors ? QStringLiteral("true")
+                               : QStringLiteral("false"));
+    out.flush();
+
+    /* TODO Phase 5: wire BatchRunner here.
+     * For now, stub — print and exit 0. */
+    return 0;
+}
 
 int main(int argc, char *argv[])
 {
+    bool batch = hasBatchFlag(argc, argv);
+
     MyApplication a(argc, argv);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     a.setAttribute(Qt::AA_UseHighDpiPixmaps);
+#endif
 #ifdef Q_OS_WIN
     a.setAttribute(Qt::AA_Use96Dpi);
 #endif
+
+    if (batch)
+    {
+        /* Batch mode — no GUI window, but QApplication stays alive
+         * because internal export code may touch widgets/fonts. */
+        a.setQuitOnLastWindowClosed(false);
+        return runBatch(a);
+    }
+
+    /* Normal GUI mode — unchanged */
     MainWindow w(argc, argv);
     w.show();
 

--- a/platform/qt/main.cpp
+++ b/platform/qt/main.cpp
@@ -86,6 +86,11 @@ static int runBatch(QCoreApplication &app)
         QStringLiteral("Use the GUI-configured default receipt."));
     parser.addOption(defaultReceiptOpt);
 
+    QCommandLineOption resumeOpt(
+        QStringLiteral("resume"),
+        QStringLiteral("Skip clips whose DNG output already matches expected frame count."));
+    parser.addOption(resumeOpt);
+
     parser.process(app);
 
     /* Init log file mirror as early as possible so that --help and
@@ -117,6 +122,8 @@ static int runBatch(QCoreApplication &app)
     QString receiptPath     = parser.value(receiptOpt);
     bool useDefaultReceipt  = parser.isSet(defaultReceiptOpt);
 
+    bool resume         = parser.isSet(resumeOpt);
+
     /* Store in BatchContext for global access */
     BatchContext::setBatchMode(true);
     BatchContext::setSkipErrors(skipErrors);
@@ -124,6 +131,7 @@ static int runBatch(QCoreApplication &app)
     BatchContext::setLogPath(logPath);
     BatchContext::setReceiptPath(receiptPath);
     BatchContext::setUseDefaultReceipt(useDefaultReceipt);
+    BatchContext::setResumeEnabled(resume);
 
     int exitCode = BatchRunner::run(inputPath, outputPath);
     BatchLogger::shutdown();

--- a/src/batch/BatchContext.cpp
+++ b/src/batch/BatchContext.cpp
@@ -5,6 +5,7 @@ bool BatchContext::s_batchMode = false;
 bool BatchContext::s_skipErrors = false;
 bool BatchContext::s_verbose = false;
 QString BatchContext::s_logPath;
+QString BatchContext::s_receiptPath;
 
 void BatchContext::setBatchMode(bool enabled) { s_batchMode = enabled; }
 bool BatchContext::isBatchMode() { return s_batchMode; }
@@ -17,3 +18,6 @@ bool BatchContext::isVerbose() { return s_verbose; }
 
 void BatchContext::setLogPath(const QString &path) { s_logPath = path; }
 QString BatchContext::logPath() { return s_logPath; }
+
+void BatchContext::setReceiptPath(const QString &path) { s_receiptPath = path; }
+QString BatchContext::receiptPath() { return s_receiptPath; }

--- a/src/batch/BatchContext.cpp
+++ b/src/batch/BatchContext.cpp
@@ -5,6 +5,7 @@ bool BatchContext::s_batchMode = false;
 bool BatchContext::s_skipErrors = false;
 bool BatchContext::s_verbose = false;
 bool BatchContext::s_useDefaultReceipt = false;
+bool BatchContext::s_resumeEnabled = false;
 QString BatchContext::s_logPath;
 QString BatchContext::s_receiptPath;
 
@@ -25,3 +26,6 @@ QString BatchContext::receiptPath() { return s_receiptPath; }
 
 void BatchContext::setUseDefaultReceipt(bool use) { s_useDefaultReceipt = use; }
 bool BatchContext::useDefaultReceipt() { return s_useDefaultReceipt; }
+
+void BatchContext::setResumeEnabled(bool enabled) { s_resumeEnabled = enabled; }
+bool BatchContext::resumeEnabled() { return s_resumeEnabled; }

--- a/src/batch/BatchContext.cpp
+++ b/src/batch/BatchContext.cpp
@@ -4,6 +4,7 @@
 bool BatchContext::s_batchMode = false;
 bool BatchContext::s_skipErrors = false;
 bool BatchContext::s_verbose = false;
+bool BatchContext::s_useDefaultReceipt = false;
 QString BatchContext::s_logPath;
 QString BatchContext::s_receiptPath;
 
@@ -21,3 +22,6 @@ QString BatchContext::logPath() { return s_logPath; }
 
 void BatchContext::setReceiptPath(const QString &path) { s_receiptPath = path; }
 QString BatchContext::receiptPath() { return s_receiptPath; }
+
+void BatchContext::setUseDefaultReceipt(bool use) { s_useDefaultReceipt = use; }
+bool BatchContext::useDefaultReceipt() { return s_useDefaultReceipt; }

--- a/src/batch/BatchContext.cpp
+++ b/src/batch/BatchContext.cpp
@@ -1,0 +1,19 @@
+#include "BatchContext.h"
+
+/* Static member definitions */
+bool BatchContext::s_batchMode = false;
+bool BatchContext::s_skipErrors = false;
+bool BatchContext::s_verbose = false;
+QString BatchContext::s_logPath;
+
+void BatchContext::setBatchMode(bool enabled) { s_batchMode = enabled; }
+bool BatchContext::isBatchMode() { return s_batchMode; }
+
+void BatchContext::setSkipErrors(bool skip) { s_skipErrors = skip; }
+bool BatchContext::skipErrors() { return s_skipErrors; }
+
+void BatchContext::setVerbose(bool verbose) { s_verbose = verbose; }
+bool BatchContext::isVerbose() { return s_verbose; }
+
+void BatchContext::setLogPath(const QString &path) { s_logPath = path; }
+QString BatchContext::logPath() { return s_logPath; }

--- a/src/batch/BatchContext.h
+++ b/src/batch/BatchContext.h
@@ -1,0 +1,34 @@
+#ifndef BATCHCONTEXT_H
+#define BATCHCONTEXT_H
+
+#include <QString>
+
+/* Static singleton holding batch-mode flags.
+ * Set once at startup from CLI args, read throughout the codebase.
+ * Intentionally uses a separate .cpp for static member definitions
+ * to avoid MinGW linker issues with inline statics. */
+class BatchContext
+{
+public:
+    static void setBatchMode(bool enabled);
+    static bool isBatchMode();
+
+    static void setSkipErrors(bool skip);
+    static bool skipErrors();
+
+    static void setVerbose(bool verbose);
+    static bool isVerbose();
+
+    static void setLogPath(const QString &path);
+    static QString logPath();
+
+private:
+    BatchContext() = delete; /* Pure static — no instances */
+
+    static bool s_batchMode;
+    static bool s_skipErrors;
+    static bool s_verbose;
+    static QString s_logPath;
+};
+
+#endif // BATCHCONTEXT_H

--- a/src/batch/BatchContext.h
+++ b/src/batch/BatchContext.h
@@ -25,12 +25,16 @@ public:
     static void setReceiptPath(const QString &path);
     static QString receiptPath();
 
+    static void setUseDefaultReceipt(bool use);
+    static bool useDefaultReceipt();
+
 private:
     BatchContext() = delete; /* Pure static — no instances */
 
     static bool s_batchMode;
     static bool s_skipErrors;
     static bool s_verbose;
+    static bool s_useDefaultReceipt;
     static QString s_logPath;
     static QString s_receiptPath;
 };

--- a/src/batch/BatchContext.h
+++ b/src/batch/BatchContext.h
@@ -22,6 +22,9 @@ public:
     static void setLogPath(const QString &path);
     static QString logPath();
 
+    static void setReceiptPath(const QString &path);
+    static QString receiptPath();
+
 private:
     BatchContext() = delete; /* Pure static — no instances */
 
@@ -29,6 +32,7 @@ private:
     static bool s_skipErrors;
     static bool s_verbose;
     static QString s_logPath;
+    static QString s_receiptPath;
 };
 
 #endif // BATCHCONTEXT_H

--- a/src/batch/BatchContext.h
+++ b/src/batch/BatchContext.h
@@ -28,6 +28,9 @@ public:
     static void setUseDefaultReceipt(bool use);
     static bool useDefaultReceipt();
 
+    static void setResumeEnabled(bool enabled);
+    static bool resumeEnabled();
+
 private:
     BatchContext() = delete; /* Pure static — no instances */
 
@@ -35,6 +38,7 @@ private:
     static bool s_skipErrors;
     static bool s_verbose;
     static bool s_useDefaultReceipt;
+    static bool s_resumeEnabled;
     static QString s_logPath;
     static QString s_receiptPath;
 };

--- a/src/batch/BatchLogger.cpp
+++ b/src/batch/BatchLogger.cpp
@@ -1,0 +1,69 @@
+#include "BatchLogger.h"
+
+#include <QFile>
+#include <QDir>
+#include <QFileInfo>
+#include <QTextStream>
+
+/* File-scope statics — no heap allocation needed.
+ * s_logFile is opened/closed by init()/shutdown(). */
+static QFile       s_logFile;
+static QTextStream s_logStream;
+static bool        s_logOpen = false;
+
+void BatchLogger::init(const QString &logPath)
+{
+    if( logPath.isEmpty() ) return;
+
+    /* Create parent directory if needed */
+    QString dir = QFileInfo(logPath).absolutePath();
+    QDir().mkpath(dir);
+
+    s_logFile.setFileName(logPath);
+    if( !s_logFile.open( QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text ) )
+    {
+        QTextStream e(stderr);
+        e << QStringLiteral("[BATCH] WARNING: Cannot open log file: %1\n").arg(logPath);
+        e.flush();
+        return;
+    }
+    s_logStream.setDevice(&s_logFile);
+    s_logOpen = true;
+}
+
+void BatchLogger::out(const QString &line)
+{
+    QTextStream o(stdout);
+    o << line;
+    o.flush();
+
+    if( s_logOpen )
+    {
+        s_logStream << line;
+        s_logStream.flush();
+    }
+}
+
+void BatchLogger::err(const QString &line)
+{
+    QTextStream e(stderr);
+    e << line;
+    e.flush();
+
+    if( s_logOpen )
+    {
+        s_logStream << line;
+        s_logStream.flush();
+    }
+}
+
+void BatchLogger::shutdown()
+{
+    if( s_logOpen )
+    {
+        s_logStream.flush();
+        s_logStream.setDevice(nullptr);
+        s_logFile.close();
+        s_logOpen = false;
+    }
+}

--- a/src/batch/BatchLogger.h
+++ b/src/batch/BatchLogger.h
@@ -1,0 +1,30 @@
+#ifndef BATCHLOGGER_H
+#define BATCHLOGGER_H
+
+#include <QString>
+
+/* Tiny static helper that mirrors batch output to a log file.
+ * stdout lines go through out(), stderr lines go through err().
+ * When no --log was given, these just write to the console. */
+class BatchLogger
+{
+public:
+    /* Open the log file.  Call once from runBatch() after parsing args.
+     * If logPath is empty, logging goes to console only.
+     * If the file can't be opened, prints a warning to stderr and continues. */
+    static void init(const QString &logPath);
+
+    /* Write a line to stdout (and mirror to log file if open). */
+    static void out(const QString &line);
+
+    /* Write a line to stderr (and mirror to log file if open). */
+    static void err(const QString &line);
+
+    /* Flush and close the log file. */
+    static void shutdown();
+
+private:
+    BatchLogger() = delete; /* Pure static — no instances */
+};
+
+#endif // BATCHLOGGER_H

--- a/src/batch/BatchPrompts.cpp
+++ b/src/batch/BatchPrompts.cpp
@@ -1,7 +1,7 @@
 #include "BatchPrompts.h"
 #include "BatchContext.h"
+#include "BatchLogger.h"
 
-#include <QTextStream>
 #include <QMessageBox>
 #include <QApplication>
 
@@ -19,19 +19,16 @@ bool BatchPrompts::shouldSkipFrame(const QString &clipName,
 {
     if( BatchContext::isBatchMode() )
     {
-        QTextStream err(stderr);
         if( BatchContext::skipErrors() )
         {
-            err << QStringLiteral("[BATCH] SKIP %1 frame=%2 error=%3\n")
-                       .arg( clipName ).arg( frameIndex ).arg( errorDetail );
-            err.flush();
+            BatchLogger::err(QStringLiteral("[BATCH] SKIP %1 frame=%2 error=%3\n")
+                       .arg( clipName ).arg( frameIndex ).arg( errorDetail ));
             return true; /* skip frame, continue */
         }
         else
         {
-            err << QStringLiteral("[BATCH] ERROR %1 frame=%2 error=%3\n")
-                       .arg( clipName ).arg( frameIndex ).arg( errorDetail );
-            err.flush();
+            BatchLogger::err(QStringLiteral("[BATCH] ERROR %1 frame=%2 error=%3\n")
+                       .arg( clipName ).arg( frameIndex ).arg( errorDetail ));
             return false; /* abort */
         }
     }
@@ -67,9 +64,7 @@ bool BatchPrompts::shouldContinue(const QString &context,
 {
     if( BatchContext::isBatchMode() )
     {
-        QTextStream err(stderr);
-        err << QStringLiteral("[BATCH] WARNING %1: %2\n").arg( context, message );
-        err.flush();
+        BatchLogger::err(QStringLiteral("[BATCH] WARNING %1: %2\n").arg( context, message ));
         /* In batch mode, disk-full is always fatal */
         return false;
     }

--- a/src/batch/BatchPrompts.cpp
+++ b/src/batch/BatchPrompts.cpp
@@ -1,0 +1,22 @@
+#include "BatchPrompts.h"
+
+/* Stub implementations — Phase 4 will add real logic using
+ * BatchContext::isBatchMode() and BatchContext::skipErrors(). */
+
+bool BatchPrompts::shouldSkipFrame(const QString &clipName,
+                                   int frameIndex,
+                                   const QString &errorDetail)
+{
+    Q_UNUSED(clipName);
+    Q_UNUSED(frameIndex);
+    Q_UNUSED(errorDetail);
+    return false; /* Abort by default until Phase 4 */
+}
+
+bool BatchPrompts::shouldContinue(const QString &context,
+                                  const QString &message)
+{
+    Q_UNUSED(context);
+    Q_UNUSED(message);
+    return false; /* Abort by default until Phase 4 */
+}

--- a/src/batch/BatchPrompts.cpp
+++ b/src/batch/BatchPrompts.cpp
@@ -1,22 +1,83 @@
 #include "BatchPrompts.h"
+#include "BatchContext.h"
 
-/* Stub implementations — Phase 4 will add real logic using
- * BatchContext::isBatchMode() and BatchContext::skipErrors(). */
+#include <QTextStream>
+#include <QMessageBox>
+#include <QApplication>
+
+/* Static member definition */
+std::function<void()> BatchPrompts::s_abortBatchFn;
+
+void BatchPrompts::setAbortBatchCallback(std::function<void()> fn)
+{
+    s_abortBatchFn = fn;
+}
 
 bool BatchPrompts::shouldSkipFrame(const QString &clipName,
                                    int frameIndex,
                                    const QString &errorDetail)
 {
-    Q_UNUSED(clipName);
-    Q_UNUSED(frameIndex);
-    Q_UNUSED(errorDetail);
-    return false; /* Abort by default until Phase 4 */
+    if( BatchContext::isBatchMode() )
+    {
+        QTextStream err(stderr);
+        if( BatchContext::skipErrors() )
+        {
+            err << QStringLiteral("[BATCH] SKIP %1 frame=%2 error=%3\n")
+                       .arg( clipName ).arg( frameIndex ).arg( errorDetail );
+            err.flush();
+            return true; /* skip frame, continue */
+        }
+        else
+        {
+            err << QStringLiteral("[BATCH] ERROR %1 frame=%2 error=%3\n")
+                       .arg( clipName ).arg( frameIndex ).arg( errorDetail );
+            err.flush();
+            return false; /* abort */
+        }
+    }
+
+    /* GUI mode — show the original 3-button QMessageBox */
+    QWidget *parent = QApplication::activeWindow();
+    int ret = QMessageBox::critical(
+        parent,
+        QObject::tr( "MLV App - Export file error" ),
+        QObject::tr( "Could not save: %1\nHow do you like to proceed?" ).arg( errorDetail ),
+        QObject::tr( "Skip frame" ),
+        QObject::tr( "Abort current export" ),
+        QObject::tr( "Abort batch export" ),
+        0, 2 );
+
+    if( ret == 2 )
+    {
+        /* "Abort batch export" — invoke the callback if set */
+        if( s_abortBatchFn ) s_abortBatchFn();
+        return false;
+    }
+    if( ret == 1 )
+    {
+        /* "Abort current export" */
+        return false;
+    }
+    /* ret == 0: "Skip frame" */
+    return true;
 }
 
 bool BatchPrompts::shouldContinue(const QString &context,
                                   const QString &message)
 {
-    Q_UNUSED(context);
-    Q_UNUSED(message);
-    return false; /* Abort by default until Phase 4 */
+    if( BatchContext::isBatchMode() )
+    {
+        QTextStream err(stderr);
+        err << QStringLiteral("[BATCH] WARNING %1: %2\n").arg( context, message );
+        err.flush();
+        /* In batch mode, disk-full is always fatal */
+        return false;
+    }
+
+    /* GUI mode — show warning dialog with context and message */
+    QWidget *parent = QApplication::activeWindow();
+    QMessageBox::warning( parent,
+        QStringLiteral("MLV App"),
+        QStringLiteral("%1: %2").arg( context, message ) );
+    return false; /* always abort on disk full */
 }

--- a/src/batch/BatchPrompts.h
+++ b/src/batch/BatchPrompts.h
@@ -1,0 +1,31 @@
+#ifndef BATCHPROMPTS_H
+#define BATCHPROMPTS_H
+
+#include <QString>
+
+/* Helper class for replacing QMessageBox dialogs in batch mode.
+ * In GUI mode, the original QMessageBox calls remain active.
+ * In batch mode, these static methods decide skip-or-abort based on
+ * BatchContext::skipErrors() and log the decision to stdout.
+ *
+ * Phase 4 will provide the real implementation.
+ * For now, both methods are stubs that return false (abort). */
+class BatchPrompts
+{
+public:
+    /* Returns true = skip this frame and continue, false = abort.
+     * Called when saveDngFrame() fails for a single frame. */
+    static bool shouldSkipFrame(const QString &clipName,
+                                int frameIndex,
+                                const QString &errorDetail);
+
+    /* Returns true = continue processing, false = abort.
+     * Called for non-frame errors (e.g. disk full, general warnings). */
+    static bool shouldContinue(const QString &context,
+                               const QString &message);
+
+private:
+    BatchPrompts() = delete; /* Pure static — no instances */
+};
+
+#endif // BATCHPROMPTS_H

--- a/src/batch/BatchPrompts.h
+++ b/src/batch/BatchPrompts.h
@@ -2,14 +2,16 @@
 #define BATCHPROMPTS_H
 
 #include <QString>
+#include <functional>
 
-/* Helper class for replacing QMessageBox dialogs in batch mode.
- * In GUI mode, the original QMessageBox calls remain active.
- * In batch mode, these static methods decide skip-or-abort based on
- * BatchContext::skipErrors() and log the decision to stdout.
+/* Helper class for dialog replacement in both batch and GUI mode.
  *
- * Phase 4 will provide the real implementation.
- * For now, both methods are stubs that return false (abort). */
+ * Batch mode: logs to stderr, returns based on BatchContext::skipErrors().
+ * GUI mode:   shows the original QMessageBox with 3 buttons
+ *             (Skip frame / Abort current export / Abort batch export).
+ *
+ * The "Abort batch export" button in GUI mode invokes an optional
+ * callback set via setAbortBatchCallback(). */
 class BatchPrompts
 {
 public:
@@ -24,8 +26,14 @@ public:
     static bool shouldContinue(const QString &context,
                                const QString &message);
 
+    /* Set a callback invoked when the GUI user clicks "Abort batch export".
+     * MainWindow wires this in its constructor to call exportAbort(). */
+    static void setAbortBatchCallback(std::function<void()> fn);
+
 private:
     BatchPrompts() = delete; /* Pure static — no instances */
+
+    static std::function<void()> s_abortBatchFn;
 };
 
 #endif // BATCHPROMPTS_H

--- a/src/batch/BatchRunner.cpp
+++ b/src/batch/BatchRunner.cpp
@@ -1,0 +1,191 @@
+#include "BatchRunner.h"
+#include "BatchContext.h"
+
+#include <QDir>
+#include <QFileInfo>
+#include <QTextStream>
+#include <QThread>
+#include <QElapsedTimer>
+
+/* MainWindow.h gives us the static exportCdngSequence helper
+ * and pulls in mlv_include.h (C API) transitively. */
+#include "../../platform/qt/MainWindow.h"
+#include "../../platform/qt/ExportSettingsDialog.h"
+#include "../../platform/qt/StretchFactors.h"
+
+int BatchRunner::run(const QString &inputPath, const QString &outputPath)
+{
+    QTextStream out(stdout);
+    QElapsedTimer totalTimer;
+    totalTimer.start();
+
+    /* Collect list of .mlv files to process */
+    QStringList mlvFiles;
+    QFileInfo inputInfo(inputPath);
+
+    if( inputInfo.isFile() )
+    {
+        if( inputPath.endsWith( QStringLiteral(".mlv"), Qt::CaseInsensitive ) )
+            mlvFiles << inputPath;
+        else
+        {
+            out << QStringLiteral("[BATCH] ERROR: Input is not an MLV file: %1\n").arg(inputPath);
+            out.flush();
+            return 3;
+        }
+    }
+    else if( inputInfo.isDir() )
+    {
+        QDir dir(inputPath);
+        QStringList filters;
+        filters << QStringLiteral("*.mlv") << QStringLiteral("*.MLV");
+        QFileInfoList entries = dir.entryInfoList( filters, QDir::Files, QDir::Name );
+        for( const QFileInfo &fi : entries )
+            mlvFiles << fi.absoluteFilePath();
+
+        if( mlvFiles.isEmpty() )
+        {
+            out << QStringLiteral("[BATCH] ERROR: No MLV files found in: %1\n").arg(inputPath);
+            out.flush();
+            return 3;
+        }
+    }
+    else
+    {
+        out << QStringLiteral("[BATCH] ERROR: Input path does not exist: %1\n").arg(inputPath);
+        out.flush();
+        return 3;
+    }
+
+    /* Ensure output directory exists */
+    QDir outDir(outputPath);
+    if( !outDir.exists() )
+    {
+        if( !outDir.mkpath( QStringLiteral(".") ) )
+        {
+            out << QStringLiteral("[BATCH] ERROR: Cannot create output directory: %1\n").arg(outputPath);
+            out.flush();
+            return 3;
+        }
+    }
+
+    out << QStringLiteral("[BATCH] START input=%1 output=%2 skip-errors=%3\n")
+               .arg( inputPath, outputPath,
+                     BatchContext::skipErrors() ? QStringLiteral("true")
+                                               : QStringLiteral("false") );
+    out.flush();
+
+    int succeeded = 0;
+    int failed = 0;
+
+    for( const QString &mlvPath : mlvFiles )
+    {
+        ProcessResult res = exportSingleFile( mlvPath, outputPath );
+
+        QString baseName = QFileInfo(mlvPath).completeBaseName();
+        if( res.success )
+        {
+            out << QStringLiteral("[BATCH] DONE %1 exported=%2 skipped=%3 elapsed=%4\n")
+                       .arg( baseName )
+                       .arg( res.framesExported )
+                       .arg( res.framesSkipped )
+                       .arg( res.elapsedSeconds, 0, 'f', 1 );
+            out.flush();
+            succeeded++;
+        }
+        else
+        {
+            out << QStringLiteral("[BATCH] FAIL %1 error=%2 exported=%3 skipped=%4 elapsed=%5\n")
+                       .arg( baseName,
+                              res.errorMessage )
+                       .arg( res.framesExported )
+                       .arg( res.framesSkipped )
+                       .arg( res.elapsedSeconds, 0, 'f', 1 );
+            out.flush();
+            failed++;
+
+            /* Without --skip-errors, abort the entire batch on first failure */
+            if( !BatchContext::skipErrors() )
+            {
+                out << QStringLiteral("[BATCH] COMPLETE files=%1 succeeded=%2 failed=%3 total_elapsed=%4\n")
+                           .arg( mlvFiles.size() ).arg( succeeded ).arg( failed )
+                           .arg( totalTimer.elapsed() / 1000.0, 0, 'f', 1 );
+                out.flush();
+                return 4;
+            }
+        }
+    }
+
+    double totalElapsed = totalTimer.elapsed() / 1000.0;
+    out << QStringLiteral("[BATCH] COMPLETE files=%1 succeeded=%2 failed=%3 total_elapsed=%4\n")
+               .arg( mlvFiles.size() ).arg( succeeded ).arg( failed )
+               .arg( totalElapsed, 0, 'f', 1 );
+    out.flush();
+
+    if( failed > 0 ) return 1;
+    return 0;
+}
+
+ProcessResult BatchRunner::exportSingleFile(const QString &mlvPath,
+                                            const QString &outputRoot)
+{
+    ProcessResult result;
+    QTextStream out(stdout);
+    QString baseName = QFileInfo(mlvPath).completeBaseName();
+
+    /* Open MLV file using the C API — same as MainWindow::openMlv() */
+    int mlvErr = MLV_ERR_NONE;
+    char mlvErrMsg[256] = { 0 };
+
+#ifdef Q_OS_UNIX
+    mlvObject_t *mlvObject = initMlvObjectWithClip(
+        mlvPath.toUtf8().data(), MLV_OPEN_FULL, &mlvErr, mlvErrMsg );
+#else
+    mlvObject_t *mlvObject = initMlvObjectWithClip(
+        mlvPath.toLatin1().data(), MLV_OPEN_FULL, &mlvErr, mlvErrMsg );
+#endif
+
+    if( mlvErr )
+    {
+        result.success = false;
+        result.errorMessage = QStringLiteral("Cannot open MLV: %1").arg( QString(mlvErrMsg) );
+        if( mlvObject ) freeMlvObject( mlvObject );
+        return result;
+    }
+
+    /* Create processing object with default settings */
+    processingObject_t *processingObject = initProcessingObject();
+    setMlvProcessing( mlvObject, processingObject );
+    disableMlvCaching( mlvObject );
+    setMlvCpuCores( mlvObject, QThread::idealThreadCount() );
+
+    uint32_t totalFrames = getMlvFrames( mlvObject );
+    out << QStringLiteral("[BATCH] FILE %1 frames=%2\n").arg( baseName ).arg( totalFrames );
+    out.flush();
+
+    /* Export using defaults:
+     * - codecProfile = CODEC_CDNG (uncompressed)
+     * - codecOption = CODEC_CNDG_DEFAULT (standard naming)
+     * - cutIn = 1, cutOut = totalFrames (all frames)
+     * - stretchX/Y = 1.0 (no stretch)
+     * - audioExport = true, rawFixEnabled = true */
+    result = MainWindow::exportCdngSequence(
+        mlvObject,
+        outputRoot,
+        baseName,
+        CODEC_CDNG,           /* uncompressed CDNG */
+        CODEC_CNDG_DEFAULT,   /* standard folder/file naming */
+        1,                    /* cutIn: first frame */
+        totalFrames,          /* cutOut: last frame */
+        STRETCH_H_100,        /* no horizontal stretch */
+        STRETCH_V_100,        /* no vertical stretch */
+        true,                 /* export audio if present */
+        true                  /* enable raw fixes */
+    );
+
+    /* Clean up */
+    freeMlvObject( mlvObject );
+    freeProcessingObject( processingObject );
+
+    return result;
+}

--- a/src/batch/BatchRunner.cpp
+++ b/src/batch/BatchRunner.cpp
@@ -1,9 +1,9 @@
 #include "BatchRunner.h"
 #include "BatchContext.h"
+#include "BatchLogger.h"
 
 #include <QDir>
 #include <QFileInfo>
-#include <QTextStream>
 #include <QThread>
 #include <QElapsedTimer>
 
@@ -15,7 +15,6 @@
 
 int BatchRunner::run(const QString &inputPath, const QString &outputPath)
 {
-    QTextStream out(stdout);
     QElapsedTimer totalTimer;
     totalTimer.start();
 
@@ -29,8 +28,7 @@ int BatchRunner::run(const QString &inputPath, const QString &outputPath)
             mlvFiles << inputPath;
         else
         {
-            out << QStringLiteral("[BATCH] ERROR: Input is not an MLV file: %1\n").arg(inputPath);
-            out.flush();
+            BatchLogger::err(QStringLiteral("[BATCH] ERROR: Input is not an MLV file: %1\n").arg(inputPath));
             return 3;
         }
     }
@@ -45,15 +43,13 @@ int BatchRunner::run(const QString &inputPath, const QString &outputPath)
 
         if( mlvFiles.isEmpty() )
         {
-            out << QStringLiteral("[BATCH] ERROR: No MLV files found in: %1\n").arg(inputPath);
-            out.flush();
+            BatchLogger::err(QStringLiteral("[BATCH] ERROR: No MLV files found in: %1\n").arg(inputPath));
             return 3;
         }
     }
     else
     {
-        out << QStringLiteral("[BATCH] ERROR: Input path does not exist: %1\n").arg(inputPath);
-        out.flush();
+        BatchLogger::err(QStringLiteral("[BATCH] ERROR: Input path does not exist: %1\n").arg(inputPath));
         return 3;
     }
 
@@ -63,17 +59,15 @@ int BatchRunner::run(const QString &inputPath, const QString &outputPath)
     {
         if( !outDir.mkpath( QStringLiteral(".") ) )
         {
-            out << QStringLiteral("[BATCH] ERROR: Cannot create output directory: %1\n").arg(outputPath);
-            out.flush();
+            BatchLogger::err(QStringLiteral("[BATCH] ERROR: Cannot create output directory: %1\n").arg(outputPath));
             return 3;
         }
     }
 
-    out << QStringLiteral("[BATCH] START input=%1 output=%2 skip-errors=%3\n")
+    BatchLogger::out(QStringLiteral("[BATCH] START input=%1 output=%2 skip-errors=%3\n")
                .arg( inputPath, outputPath,
                      BatchContext::skipErrors() ? QStringLiteral("true")
-                                               : QStringLiteral("false") );
-    out.flush();
+                                               : QStringLiteral("false") ));
 
     int succeeded = 0;
     int failed = 0;
@@ -85,42 +79,38 @@ int BatchRunner::run(const QString &inputPath, const QString &outputPath)
         QString baseName = QFileInfo(mlvPath).completeBaseName();
         if( res.success )
         {
-            out << QStringLiteral("[BATCH] DONE %1 exported=%2 skipped=%3 elapsed=%4\n")
+            BatchLogger::out(QStringLiteral("[BATCH] DONE %1 exported=%2 skipped=%3 elapsed=%4\n")
                        .arg( baseName )
                        .arg( res.framesExported )
                        .arg( res.framesSkipped )
-                       .arg( res.elapsedSeconds, 0, 'f', 1 );
-            out.flush();
+                       .arg( res.elapsedSeconds, 0, 'f', 1 ));
             succeeded++;
         }
         else
         {
-            out << QStringLiteral("[BATCH] FAIL %1 error=%2 exported=%3 skipped=%4 elapsed=%5\n")
+            BatchLogger::out(QStringLiteral("[BATCH] FAIL %1 error=%2 exported=%3 skipped=%4 elapsed=%5\n")
                        .arg( baseName,
                               res.errorMessage )
                        .arg( res.framesExported )
                        .arg( res.framesSkipped )
-                       .arg( res.elapsedSeconds, 0, 'f', 1 );
-            out.flush();
+                       .arg( res.elapsedSeconds, 0, 'f', 1 ));
             failed++;
 
             /* Without --skip-errors, abort the entire batch on first failure */
             if( !BatchContext::skipErrors() )
             {
-                out << QStringLiteral("[BATCH] COMPLETE files=%1 succeeded=%2 failed=%3 total_elapsed=%4\n")
+                BatchLogger::out(QStringLiteral("[BATCH] COMPLETE files=%1 succeeded=%2 failed=%3 total_elapsed=%4\n")
                            .arg( mlvFiles.size() ).arg( succeeded ).arg( failed )
-                           .arg( totalTimer.elapsed() / 1000.0, 0, 'f', 1 );
-                out.flush();
+                           .arg( totalTimer.elapsed() / 1000.0, 0, 'f', 1 ));
                 return 4;
             }
         }
     }
 
     double totalElapsed = totalTimer.elapsed() / 1000.0;
-    out << QStringLiteral("[BATCH] COMPLETE files=%1 succeeded=%2 failed=%3 total_elapsed=%4\n")
+    BatchLogger::out(QStringLiteral("[BATCH] COMPLETE files=%1 succeeded=%2 failed=%3 total_elapsed=%4\n")
                .arg( mlvFiles.size() ).arg( succeeded ).arg( failed )
-               .arg( totalElapsed, 0, 'f', 1 );
-    out.flush();
+               .arg( totalElapsed, 0, 'f', 1 ));
 
     if( failed > 0 ) return 1;
     return 0;
@@ -130,7 +120,6 @@ ProcessResult BatchRunner::exportSingleFile(const QString &mlvPath,
                                             const QString &outputRoot)
 {
     ProcessResult result;
-    QTextStream out(stdout);
     QString baseName = QFileInfo(mlvPath).completeBaseName();
 
     /* Open MLV file using the C API — same as MainWindow::openMlv() */
@@ -160,8 +149,7 @@ ProcessResult BatchRunner::exportSingleFile(const QString &mlvPath,
     setMlvCpuCores( mlvObject, QThread::idealThreadCount() );
 
     uint32_t totalFrames = getMlvFrames( mlvObject );
-    out << QStringLiteral("[BATCH] FILE %1 frames=%2\n").arg( baseName ).arg( totalFrames );
-    out.flush();
+    BatchLogger::out(QStringLiteral("[BATCH] FILE %1 frames=%2\n").arg( baseName ).arg( totalFrames ));
 
     /* Export using defaults:
      * - codecProfile = CODEC_CDNG (uncompressed)

--- a/src/batch/BatchRunner.cpp
+++ b/src/batch/BatchRunner.cpp
@@ -157,10 +157,12 @@ int BatchRunner::run(const QString &inputPath, const QString &outputPath)
         }
     }
 
-    BatchLogger::out(QStringLiteral("[BATCH] START input=%1 output=%2 skip-errors=%3\n")
+    BatchLogger::out(QStringLiteral("[BATCH] START input=%1 output=%2 skip-errors=%3 resume=%4\n")
                .arg( inputPath, outputPath,
                      BatchContext::skipErrors() ? QStringLiteral("true")
-                                               : QStringLiteral("false") ));
+                                               : QStringLiteral("false"),
+                     BatchContext::resumeEnabled() ? QStringLiteral("true")
+                                                   : QStringLiteral("false") ));
 
     int succeeded = 0;
     int failed = 0;
@@ -245,28 +247,142 @@ ProcessResult BatchRunner::exportSingleFile(const QString &mlvPath,
     uint32_t totalFrames = getMlvFrames( mlvObject );
     BatchLogger::out(QStringLiteral("[BATCH] FILE %1 frames=%2\n").arg( baseName ).arg( totalFrames ));
 
-    /* ---- Phase 6B: Apply receipt settings to the MLV pipeline ----
-     * This calls the same C API functions the GUI's setSliders() triggers.
-     * Works with both default-constructed receipts (no-op for most settings)
-     * and receipts loaded from .marxml files. */
-    ReceiptApplier::applyToMlv( receipt, mlvObject, processingObject );
-
-    /* Print runtime FINGERPRINT — proves settings reached the pipeline */
-    ReceiptApplier::printFingerprint( mlvObject, processingObject );
-
     /* ---- Derive export parameters from receipt ----
      * cutIn/cutOut: use receipt values if set, else export all frames.
-     * stretchX/Y: use receipt values if set, else no stretch. */
+     * stretchX/Y: use receipt values if set, else no stretch.
+     * NOTE: These must be computed BEFORE resume logic (which adjusts cutIn)
+     * and BEFORE applyToMlv (which may mutate receipt fields). */
     uint32_t cutIn  = receipt->cutIn();
     uint32_t cutOut = receipt->cutOut();
     if( cutIn == 0 )  cutIn  = 1;
     if( cutOut == 0 || cutOut > totalFrames ) cutOut = totalFrames;
+
+    uint32_t effectiveCutIn = cutIn;  /* may be adjusted by resume */
 
     double stretchX = receipt->stretchFactorX();
     double stretchY = receipt->stretchFactorY();
     /* -1 = uninitialized (never loaded); use no-stretch defaults */
     if( stretchX <= 0 ) stretchX = STRETCH_H_100;
     if( stretchY <= 0 ) stretchY = STRETCH_V_100;
+
+    /* ---- Resume logic (--resume flag) ----
+     * Scan the output subfolder for existing DNG files.  If the clip is
+     * already fully exported, skip it entirely (exit 0, no file deletion).
+     * If partially exported, advance cutIn past the last completed frame. */
+    if( BatchContext::resumeEnabled() )
+    {
+        QString subFolder = outputRoot + QStringLiteral("/") + baseName;
+        QDir subDir(subFolder);
+
+        if( subDir.exists() )
+        {
+            /* Scan for clipBaseName_NNNNNN.dng files */
+            QStringList dngFilter;
+            dngFilter << baseName + QStringLiteral("_*.dng");
+            QFileInfoList dngFiles = subDir.entryInfoList( dngFilter, QDir::Files );
+
+            if( !dngFiles.isEmpty() )
+            {
+                /* Find the highest numeric suffix among existing DNG files.
+                 * Filename pattern: clipBaseName_NNNNNN.dng
+                 * We extract NNNNNN from each matching file. */
+                uint32_t highestSuffix = 0;
+                int validCount = 0;
+                QString prefix = baseName + QStringLiteral("_");
+
+                for( const QFileInfo &fi : dngFiles )
+                {
+                    QString fn = fi.completeBaseName(); /* clipBaseName_NNNNNN */
+                    if( !fn.startsWith(prefix) ) continue;
+                    QString numStr = fn.mid( prefix.length() );
+                    bool ok = false;
+                    uint32_t num = numStr.toUInt( &ok );
+                    if( ok )
+                    {
+                        validCount++;
+                        if( num > highestSuffix ) highestSuffix = num;
+                    }
+                }
+
+                if( validCount > 0 )
+                {
+                    /* Map suffix → frame_index by scanning video_index[].
+                     * Do NOT assume suffix == frame_index.  The MLV file's
+                     * VIDF blocks store arbitrary frame_number values. */
+                    int resumeFrameIndex = -1;
+                    for( uint32_t fi = 0; fi < totalFrames; fi++ )
+                    {
+                        if( getMlvFrameNumber( mlvObject, fi ) == highestSuffix )
+                        {
+                            resumeFrameIndex = (int)fi;
+                            break;
+                        }
+                    }
+
+                    if( resumeFrameIndex >= 0 )
+                    {
+                        /* Convert to 1-based cutIn: next frame after last completed */
+                        uint32_t newCutIn = (uint32_t)resumeFrameIndex + 2; /* +1 for 0→1-based, +1 for next */
+
+                        if( newCutIn > cutOut )
+                        {
+                            /* Already complete — do NOT delete files, just log and skip */
+                            BatchLogger::out(QStringLiteral("[BATCH] RESUME %1 already_complete existing=%2 highestSuffix=%3\n")
+                                       .arg( baseName ).arg( validCount ).arg( highestSuffix ));
+                            result.success = true;
+                            result.framesExported = 0;
+                            result.framesSkipped = cutOut - cutIn + 1;
+                            result.elapsedSeconds = 0.0;
+                            freeMlvObject( mlvObject );
+                            freeProcessingObject( processingObject );
+                            return result;
+                        }
+
+                        /* Clamp: never go below the receipt's original cutIn */
+                        if( newCutIn > cutIn )
+                        {
+                            effectiveCutIn = newCutIn;
+                            BatchLogger::out(QStringLiteral("[BATCH] RESUME %1 advancing cutIn=%2 (was %3) existing=%4 highestSuffix=%5\n")
+                                       .arg( baseName ).arg( effectiveCutIn ).arg( cutIn )
+                                       .arg( validCount ).arg( highestSuffix ));
+                        }
+                        else
+                        {
+                            BatchLogger::out(QStringLiteral("[BATCH] RESUME %1 no_advance highestSuffix=%2 maps_to_frame=%3 below_cutIn=%4\n")
+                                       .arg( baseName ).arg( highestSuffix )
+                                       .arg( resumeFrameIndex ).arg( cutIn ));
+                        }
+                    }
+                    else
+                    {
+                        /* Suffix not found in video_index — files may be from a different clip.
+                         * Play it safe: export from original cutIn (overwrite). */
+                        BatchLogger::out(QStringLiteral("[BATCH] RESUME %1 suffix_not_found highestSuffix=%2 exporting_from=%3\n")
+                                   .arg( baseName ).arg( highestSuffix ).arg( cutIn ));
+                    }
+                }
+            }
+            else
+            {
+                BatchLogger::out(QStringLiteral("[BATCH] RESUME %1 no_existing_frames\n").arg( baseName ));
+            }
+        }
+        else
+        {
+            BatchLogger::out(QStringLiteral("[BATCH] RESUME %1 no_output_folder\n").arg( baseName ));
+        }
+    }
+
+    /* ---- Apply receipt settings to the MLV pipeline ----
+     * This calls the same C API functions the GUI's setSliders() triggers.
+     * Works with both default-constructed receipts (no-op for most settings)
+     * and receipts loaded from .marxml files.
+     * Must happen AFTER resume logic (which needs raw mlvObject state for
+     * video_index scanning) but BEFORE the export call. */
+    ReceiptApplier::applyToMlv( receipt, mlvObject, processingObject );
+
+    /* Print runtime FINGERPRINT — proves settings reached the pipeline */
+    ReceiptApplier::printFingerprint( mlvObject, processingObject );
 
     /* Export CDNG sequence */
     result = MainWindow::exportCdngSequence(
@@ -275,7 +391,7 @@ ProcessResult BatchRunner::exportSingleFile(const QString &mlvPath,
         baseName,
         CODEC_CDNG,           /* uncompressed CDNG */
         CODEC_CNDG_DEFAULT,   /* standard folder/file naming */
-        cutIn,                /* from receipt or 1 */
+        effectiveCutIn,       /* from receipt, possibly advanced by --resume */
         cutOut,               /* from receipt or totalFrames */
         stretchX,             /* from receipt or STRETCH_H_100 */
         stretchY,             /* from receipt or STRETCH_V_100 */

--- a/src/batch/BatchRunner.cpp
+++ b/src/batch/BatchRunner.cpp
@@ -2,6 +2,7 @@
 #include "BatchContext.h"
 #include "BatchLogger.h"
 #include "ReceiptLoader.h"
+#include "ReceiptApplier.h"
 
 #include <QDir>
 #include <QFileInfo>
@@ -166,7 +167,7 @@ int BatchRunner::run(const QString &inputPath, const QString &outputPath)
 
     for( const QString &mlvPath : mlvFiles )
     {
-        ProcessResult res = exportSingleFile( mlvPath, outputPath );
+        ProcessResult res = exportSingleFile( mlvPath, outputPath, &receipt );
 
         QString baseName = QFileInfo(mlvPath).completeBaseName();
         if( res.success )
@@ -209,7 +210,8 @@ int BatchRunner::run(const QString &inputPath, const QString &outputPath)
 }
 
 ProcessResult BatchRunner::exportSingleFile(const QString &mlvPath,
-                                            const QString &outputRoot)
+                                            const QString &outputRoot,
+                                            ReceiptSettings *receipt)
 {
     ProcessResult result;
     QString baseName = QFileInfo(mlvPath).completeBaseName();
@@ -243,24 +245,42 @@ ProcessResult BatchRunner::exportSingleFile(const QString &mlvPath,
     uint32_t totalFrames = getMlvFrames( mlvObject );
     BatchLogger::out(QStringLiteral("[BATCH] FILE %1 frames=%2\n").arg( baseName ).arg( totalFrames ));
 
-    /* Export using defaults:
-     * - codecProfile = CODEC_CDNG (uncompressed)
-     * - codecOption = CODEC_CNDG_DEFAULT (standard naming)
-     * - cutIn = 1, cutOut = totalFrames (all frames)
-     * - stretchX/Y = 1.0 (no stretch)
-     * - audioExport = true, rawFixEnabled = true */
+    /* ---- Phase 6B: Apply receipt settings to the MLV pipeline ----
+     * This calls the same C API functions the GUI's setSliders() triggers.
+     * Works with both default-constructed receipts (no-op for most settings)
+     * and receipts loaded from .marxml files. */
+    ReceiptApplier::applyToMlv( receipt, mlvObject, processingObject );
+
+    /* Print runtime FINGERPRINT — proves settings reached the pipeline */
+    ReceiptApplier::printFingerprint( mlvObject, processingObject );
+
+    /* ---- Derive export parameters from receipt ----
+     * cutIn/cutOut: use receipt values if set, else export all frames.
+     * stretchX/Y: use receipt values if set, else no stretch. */
+    uint32_t cutIn  = receipt->cutIn();
+    uint32_t cutOut = receipt->cutOut();
+    if( cutIn == 0 )  cutIn  = 1;
+    if( cutOut == 0 || cutOut > totalFrames ) cutOut = totalFrames;
+
+    double stretchX = receipt->stretchFactorX();
+    double stretchY = receipt->stretchFactorY();
+    /* -1 = uninitialized (never loaded); use no-stretch defaults */
+    if( stretchX <= 0 ) stretchX = STRETCH_H_100;
+    if( stretchY <= 0 ) stretchY = STRETCH_V_100;
+
+    /* Export CDNG sequence */
     result = MainWindow::exportCdngSequence(
         mlvObject,
         outputRoot,
         baseName,
         CODEC_CDNG,           /* uncompressed CDNG */
         CODEC_CNDG_DEFAULT,   /* standard folder/file naming */
-        1,                    /* cutIn: first frame */
-        totalFrames,          /* cutOut: last frame */
-        STRETCH_H_100,        /* no horizontal stretch */
-        STRETCH_V_100,        /* no vertical stretch */
+        cutIn,                /* from receipt or 1 */
+        cutOut,               /* from receipt or totalFrames */
+        stretchX,             /* from receipt or STRETCH_H_100 */
+        stretchY,             /* from receipt or STRETCH_V_100 */
         true,                 /* export audio if present */
-        true                  /* enable raw fixes */
+        receipt->rawFixesEnabled()  /* from receipt */
     );
 
     /* Clean up */

--- a/src/batch/BatchRunner.cpp
+++ b/src/batch/BatchRunner.cpp
@@ -1,6 +1,7 @@
 #include "BatchRunner.h"
 #include "BatchContext.h"
 #include "BatchLogger.h"
+#include "ReceiptLoader.h"
 
 #include <QDir>
 #include <QFileInfo>
@@ -12,11 +13,32 @@
 #include "../../platform/qt/MainWindow.h"
 #include "../../platform/qt/ExportSettingsDialog.h"
 #include "../../platform/qt/StretchFactors.h"
+#include "../../platform/qt/ReceiptSettings.h"
 
 int BatchRunner::run(const QString &inputPath, const QString &outputPath)
 {
     QElapsedTimer totalTimer;
     totalTimer.start();
+
+    /* --- Receipt loading (Phase 6A: parse + print, do NOT apply) --- */
+    QString receiptPath = BatchContext::receiptPath();
+    ReceiptSettings receipt;  /* default-constructed */
+
+    if( !receiptPath.isEmpty() )
+    {
+        QString errMsg;
+        if( !ReceiptLoader::loadFromFile(receiptPath, &receipt, &errMsg) )
+        {
+            BatchLogger::err(QStringLiteral("[BATCH] ERROR: %1\n").arg(errMsg));
+            return 5;
+        }
+        BatchLogger::out(QStringLiteral("[BATCH] Receipt loaded: %1\n").arg(receiptPath));
+        ReceiptLoader::printCdngSettings(&receipt);
+    }
+    else
+    {
+        BatchLogger::out(QStringLiteral("[BATCH] Using default settings (no --receipt provided)\n"));
+    }
 
     /* Collect list of .mlv files to process */
     QStringList mlvFiles;

--- a/src/batch/BatchRunner.cpp
+++ b/src/batch/BatchRunner.cpp
@@ -7,6 +7,7 @@
 #include <QFileInfo>
 #include <QThread>
 #include <QElapsedTimer>
+#include <QSettings>
 
 /* MainWindow.h gives us the static exportCdngSequence helper
  * and pulls in mlv_include.h (C API) transitively. */
@@ -20,24 +21,93 @@ int BatchRunner::run(const QString &inputPath, const QString &outputPath)
     QElapsedTimer totalTimer;
     totalTimer.start();
 
-    /* --- Receipt loading (Phase 6A: parse + print, do NOT apply) --- */
+    /* --- Receipt resolution (4-way priority) ---
+     * 1. --receipt <file>       → explicit, exit 5 on failure
+     * 2. --default-receipt      → GUI default, exit 5 if not configured/missing
+     * 3. auto-detect            → GUI default if enabled in QSettings, warn on missing
+     * 4. none                   → use defaults */
     QString receiptPath = BatchContext::receiptPath();
+    bool useDefault     = BatchContext::useDefaultReceipt();
     ReceiptSettings receipt;  /* default-constructed */
 
     if( !receiptPath.isEmpty() )
     {
+        /* Priority 1: explicit --receipt <file> (wins over --default-receipt) */
         QString errMsg;
         if( !ReceiptLoader::loadFromFile(receiptPath, &receipt, &errMsg) )
         {
             BatchLogger::err(QStringLiteral("[BATCH] ERROR: %1\n").arg(errMsg));
             return 5;
         }
-        BatchLogger::out(QStringLiteral("[BATCH] Receipt loaded: %1\n").arg(receiptPath));
+        BatchLogger::out(QStringLiteral("[BATCH] RECEIPT source=explicit path=%1\n").arg(receiptPath));
+        ReceiptLoader::printCdngSettings(&receipt);
+    }
+    else if( useDefault )
+    {
+        /* Priority 2: --default-receipt flag — read GUI's QSettings */
+        QSettings set( QSettings::UserScope,
+                       QStringLiteral("magiclantern.MLVApp"),
+                       QStringLiteral("MLVApp") );
+        QString defaultPath = set.value( QStringLiteral("defaultReceiptFileName"),
+                                         QDir::homePath() ).toString();
+        bool defaultEnabled = set.value( QStringLiteral("defaultReceiptEnabled"),
+                                         false ).toBool();
+
+        if( !defaultEnabled || defaultPath.isEmpty() || defaultPath == QDir::homePath() )
+        {
+            BatchLogger::err(QStringLiteral("[BATCH] ERROR: --default-receipt requested but no default receipt configured in GUI\n"));
+            return 5;
+        }
+
+        QString errMsg;
+        if( !ReceiptLoader::loadFromFile(defaultPath, &receipt, &errMsg) )
+        {
+            BatchLogger::err(QStringLiteral("[BATCH] ERROR: %1\n").arg(errMsg));
+            return 5;
+        }
+        BatchLogger::out(QStringLiteral("[BATCH] RECEIPT source=default path=%1\n").arg(defaultPath));
         ReceiptLoader::printCdngSettings(&receipt);
     }
     else
     {
-        BatchLogger::out(QStringLiteral("[BATCH] Using default settings (no --receipt provided)\n"));
+        /* Priority 3: auto-detect — check GUI QSettings silently */
+        QSettings set( QSettings::UserScope,
+                       QStringLiteral("magiclantern.MLVApp"),
+                       QStringLiteral("MLVApp") );
+        bool defaultEnabled = set.value( QStringLiteral("defaultReceiptEnabled"),
+                                         false ).toBool();
+
+        if( defaultEnabled )
+        {
+            QString defaultPath = set.value( QStringLiteral("defaultReceiptFileName"),
+                                             QDir::homePath() ).toString();
+
+            if( !defaultPath.isEmpty() && defaultPath != QDir::homePath()
+                && QFileInfo::exists(defaultPath) )
+            {
+                QString errMsg;
+                if( ReceiptLoader::loadFromFile(defaultPath, &receipt, &errMsg) )
+                {
+                    BatchLogger::out(QStringLiteral("[BATCH] RECEIPT source=auto-default path=%1\n").arg(defaultPath));
+                    ReceiptLoader::printCdngSettings(&receipt);
+                }
+                else
+                {
+                    BatchLogger::err(QStringLiteral("[BATCH] WARNING default receipt failed to parse: %1 (using defaults)\n").arg(errMsg));
+                    BatchLogger::out(QStringLiteral("[BATCH] RECEIPT source=none (using defaults)\n"));
+                }
+            }
+            else
+            {
+                BatchLogger::err(QStringLiteral("[BATCH] WARNING default receipt missing: %1 (using defaults)\n").arg(defaultPath));
+                BatchLogger::out(QStringLiteral("[BATCH] RECEIPT source=none (using defaults)\n"));
+            }
+        }
+        else
+        {
+            /* Priority 4: no receipt at all */
+            BatchLogger::out(QStringLiteral("[BATCH] RECEIPT source=none (using defaults)\n"));
+        }
     }
 
     /* Collect list of .mlv files to process */

--- a/src/batch/BatchRunner.h
+++ b/src/batch/BatchRunner.h
@@ -4,6 +4,8 @@
 #include <QString>
 #include "BatchTypes.h"
 
+class ReceiptSettings;
+
 /* Orchestrates headless batch CDNG export.
  * Called from main.cpp after CLI args are parsed.
  * Opens each MLV, calls MainWindow::exportCdngSequence(), logs results. */
@@ -19,9 +21,12 @@ public:
 private:
     BatchRunner() = delete; /* Pure static */
 
-    /* Export a single MLV file.  Returns ProcessResult. */
+    /* Export a single MLV file.  receipt may be default-constructed
+     * (no receipt loaded) or populated from .marxml parsing.
+     * Returns ProcessResult. */
     static ProcessResult exportSingleFile(const QString &mlvPath,
-                                          const QString &outputRoot);
+                                          const QString &outputRoot,
+                                          ReceiptSettings *receipt);
 };
 
 #endif // BATCHRUNNER_H

--- a/src/batch/BatchRunner.h
+++ b/src/batch/BatchRunner.h
@@ -1,0 +1,27 @@
+#ifndef BATCHRUNNER_H
+#define BATCHRUNNER_H
+
+#include <QString>
+#include "BatchTypes.h"
+
+/* Orchestrates headless batch CDNG export.
+ * Called from main.cpp after CLI args are parsed.
+ * Opens each MLV, calls MainWindow::exportCdngSequence(), logs results. */
+class BatchRunner
+{
+public:
+    /* Run the batch export.
+     * inputPath: single .mlv file or folder of .mlv files
+     * outputPath: root output directory
+     * Returns process exit code (see CLAUDE.md exit code table). */
+    static int run(const QString &inputPath, const QString &outputPath);
+
+private:
+    BatchRunner() = delete; /* Pure static */
+
+    /* Export a single MLV file.  Returns ProcessResult. */
+    static ProcessResult exportSingleFile(const QString &mlvPath,
+                                          const QString &outputRoot);
+};
+
+#endif // BATCHRUNNER_H

--- a/src/batch/BatchTypes.h
+++ b/src/batch/BatchTypes.h
@@ -1,0 +1,31 @@
+#ifndef BATCHTYPES_H
+#define BATCHTYPES_H
+
+#include <QString>
+
+/* Shared type header for batch mode.
+ * Include this instead of MainWindow.h to avoid circular dependencies.
+ * Keep this header lightweight — no Qt widget includes. */
+
+/* Processing profile for batch export.
+ * v1 (Phases 1-5): Uses MLV-App defaults on file open. Only receiptPath
+ * and exportFormat are stored here.
+ * v1.1 (Phase 6): receiptPath will point to a .marxml file whose parsed
+ * settings are applied to the mlvObject_t before export. */
+struct ProcessingProfile
+{
+    QString receiptPath;                 /* Path to .marxml receipt (Phase 6) */
+    QString exportFormat = QStringLiteral("cdng"); /* Export format identifier */
+};
+
+/* Result of exporting a single MLV clip to CDNG. */
+struct ProcessResult
+{
+    bool success = false;
+    QString errorMessage;
+    int framesExported = 0;
+    int framesSkipped = 0;
+    double elapsedSeconds = 0.0;
+};
+
+#endif // BATCHTYPES_H

--- a/src/batch/ReceiptApplier.cpp
+++ b/src/batch/ReceiptApplier.cpp
@@ -1,0 +1,363 @@
+#include "ReceiptApplier.h"
+#include "BatchContext.h"
+#include "BatchLogger.h"
+
+#include "../../platform/qt/ReceiptSettings.h"
+
+#include <QFileInfo>
+
+/* -----------------------------------------------------------------------
+ * applyToMlv()
+ *
+ * Replicates the NET EFFECT of MainWindow::setSliders() on the
+ * mlvObject_t / processingObject_t, bypassing the GUI signal chain.
+ *
+ * The code below is a faithful extraction of every C API call that
+ * setSliders() triggers through its setToolButton*() → toolButton*Changed()
+ * signal chain, plus the direct struct assignments for dual ISO.
+ *
+ * ORDERING matches setSliders() exactly.
+ * ----------------------------------------------------------------------- */
+
+void ReceiptApplier::applyToMlv(ReceiptSettings *receipt,
+                                 mlvObject_t *mlvObject,
+                                 processingObject_t *processingObject)
+{
+    /* ---- Raw fixes enable/disable ---- */
+    llrpSetFixRawMode( mlvObject, (int)receipt->rawFixesEnabled() );
+
+    /* ---- Focus pixels ----
+     * -1 = auto-detect (first load), else use receipt value */
+    if( receipt->focusPixels() == -1 )
+    {
+        llrpSetFocusPixelMode( mlvObject, llrpDetectFocusDotFixMode( mlvObject ) );
+    }
+    else
+    {
+        llrpSetFocusPixelMode( mlvObject, receipt->focusPixels() );
+    }
+    llrpResetFpmStatus( mlvObject );
+    llrpResetBpmStatus( mlvObject );
+
+    /* ---- Focus pixels interpolation method ---- */
+    llrpSetFocusPixelInterpolationMethod( mlvObject, receipt->fpiMethod() );
+
+    /* ---- Bad pixels ---- */
+    llrpSetBadPixelMode( mlvObject, receipt->badPixels() );
+    llrpResetBpmStatus( mlvObject );
+
+    /* ---- Bad pixels search method ---- */
+    llrpSetBadPixelSearchMethod( mlvObject, receipt->bpsMethod() );
+    llrpResetBpmStatus( mlvObject );
+
+    /* ---- Bad pixels interpolation method ---- */
+    llrpSetBadPixelInterpolationMethod( mlvObject, receipt->bpiMethod() );
+
+    /* ---- Chroma smooth ----
+     * Receipt stores toolButton index 0-3 which maps 1:1 to
+     * CS_OFF=0, CS_2x2=1, CS_3x3=2, CS_5x5=3 enum values. */
+    llrpSetChromaSmoothMode( mlvObject, receipt->chromaSmooth() );
+
+    /* ---- Pattern noise ---- */
+    llrpSetPatternNoiseMode( mlvObject, receipt->patternNoise() );
+
+    /* ---- Upside down ---- */
+    processingSetTransformation( processingObject, receipt->upsideDown() );
+
+    /* ---- Vertical stripes ----
+     * -1 = auto-detect: enable for Canon 5D3 (cameraModel 0x80000285) */
+    if( receipt->verticalStripes() == -1 )
+    {
+        if( getMlvCameraModel( mlvObject ) == 0x80000285 )
+            llrpSetVerticalStripeMode( mlvObject, 1 );
+        else
+            llrpSetVerticalStripeMode( mlvObject, 0 );
+    }
+    else
+    {
+        llrpSetVerticalStripeMode( mlvObject, receipt->verticalStripes() );
+    }
+    llrpComputeStripesOn( mlvObject );
+    llrpResetFpmStatus( mlvObject );
+    llrpResetBpmStatus( mlvObject );
+
+    /* ==== Dual ISO — complex logic faithfully extracted from setSliders() ==== */
+
+    /* Step 1: Resolve dualIsoForced (-1 = uninitialized) */
+    if( receipt->dualIsoForced() == -1 )
+    {
+        receipt->setDualIsoForced( llrpGetDualIsoValidity( mlvObject ) );
+    }
+    else if( receipt->dualIsoForced() == DISO_FORCED
+             && llrpGetDualIsoValidity( mlvObject ) == DISO_VALID )
+    {
+        receipt->setDualIsoForced( DISO_VALID );
+    }
+    else if( receipt->dualIsoForced() == DISO_VALID
+             && llrpGetDualIsoValidity( mlvObject ) != DISO_VALID )
+    {
+        receipt->setDualIsoForced( DISO_FORCED );
+    }
+
+    /* Step 2: If forced, set validity flag */
+    if( receipt->dualIsoForced() == DISO_FORCED )
+    {
+        llrpSetDualIsoValidity( mlvObject, 1 );
+    }
+
+    /* Step 3: Reset diso_auto_correction sign (matches GUI logic) */
+    if( mlvObject->llrawproc->diso_auto_correction > 0 )
+    {
+        mlvObject->llrawproc->diso_auto_correction =
+            -mlvObject->llrawproc->diso_auto_correction;
+    }
+
+    /* Step 4: Handle auto-corrected vs non-auto-corrected dual ISO */
+    if( !receipt->dualIsoAutoCorrected() )
+    {
+        receipt->setDualIso( 0 );
+
+        if( receipt->dualIsoForced() == DISO_VALID )
+        {
+            /* Enable dual ISO if the two ISO levels actually differ */
+            if( mlvObject->llrawproc->diso1 != mlvObject->llrawproc->diso2 )
+            {
+                receipt->setDualIso( 1 );
+            }
+            mlvObject->llrawproc->diso_pattern = 0;
+            mlvObject->llrawproc->diso_auto_correction = -1;
+            mlvObject->llrawproc->diso_ev_correction = 1;
+            mlvObject->llrawproc->diso_black_delta = -1;
+        }
+        else
+        {
+            /* Not VALID — set pattern/ev/black to zeroed defaults
+             * (mirrors the GUI setting combobox=0, sliders=0) */
+            mlvObject->llrawproc->diso_pattern = 0;
+            mlvObject->llrawproc->diso_ev_correction = 0;
+            mlvObject->llrawproc->diso_black_delta = 0;
+        }
+
+        /* Forced overrides — after the above branches */
+        if( receipt->dualIsoForced() == DISO_FORCED )
+        {
+            mlvObject->llrawproc->diso_pattern = 0;
+            mlvObject->llrawproc->diso_auto_correction = -2;
+            mlvObject->llrawproc->diso_ev_correction = 1;
+            mlvObject->llrawproc->diso_black_delta = -1;
+        }
+    }
+    else
+    {
+        /* Auto-corrected: apply receipt values directly to struct members
+         * (matches on_DualIsoPatternComboBox_currentIndexChanged,
+         *  on_horizontalSliderDualIsoEvCorrection_valueChanged,
+         *  on_horizontalSliderDualIsoBlackDelta_valueChanged) */
+        mlvObject->llrawproc->diso_pattern = receipt->dualIsoPattern();
+
+        /* EV correction: receipt stores the slider int value.
+         * Slider value 1 is special (triggers auto-correct toggle),
+         * other values are divided by 200.0 for the actual EV offset. */
+        int evSliderVal = receipt->dualIsoEvCorrection();
+        if( evSliderVal != 1 )
+        {
+            mlvObject->llrawproc->diso_ev_correction = evSliderVal / 200.0;
+        }
+        else
+        {
+            /* Value 1 = toggle auto correction sign */
+            mlvObject->llrawproc->diso_auto_correction =
+                -mlvObject->llrawproc->diso_auto_correction;
+        }
+
+        /* Black delta: -1 is special (triggers auto-correct toggle),
+         * other values are used directly. */
+        int bdSliderVal = receipt->dualIsoBlackDelta();
+        if( bdSliderVal != -1 )
+        {
+            mlvObject->llrawproc->diso_black_delta = bdSliderVal;
+        }
+        else
+        {
+            mlvObject->llrawproc->diso_auto_correction =
+                -mlvObject->llrawproc->diso_auto_correction;
+        }
+    }
+
+    /* Step 5: Set dual ISO mode and reset levels */
+    llrpSetDualIsoMode( mlvObject, receipt->dualIso() );
+    processingSetBlackAndWhiteLevel( mlvObject->processing,
+                                     getMlvBlackLevel( mlvObject ),
+                                     getMlvWhiteLevel( mlvObject ),
+                                     getMlvBitdepth( mlvObject ) );
+    llrpResetDngBWLevels( mlvObject );
+
+    /* Step 6: Dual ISO interpolation / alias map / fullres blending */
+    llrpSetDualIsoInterpolationMethod( mlvObject, receipt->dualIsoInterpolation() );
+    llrpSetDualIsoAliasMapMode( mlvObject, receipt->dualIsoAliasMap() );
+    llrpSetDualIsoFullResBlendingMode( mlvObject, receipt->dualIsoFrBlending() );
+
+    /* ---- Deflicker target ---- */
+    llrpSetDeflickerTarget( mlvObject, receipt->deflickerTarget() );
+
+    /* ---- Dark frame ----
+     * Load external dark frame file first (if valid), then set mode. */
+    {
+        QString dfName = receipt->darkFrameFileName();
+        if( QFileInfo( dfName ).exists()
+            && dfName.endsWith( QStringLiteral(".MLV"), Qt::CaseInsensitive ) )
+        {
+#ifdef Q_OS_UNIX
+            QByteArray dfBytes = dfName.toUtf8();
+#else
+            QByteArray dfBytes = dfName.toLatin1();
+#endif
+            char errorMessage[256] = { 0 };
+            int ret = llrpValidateExtDarkFrame( mlvObject, dfBytes.data(), errorMessage );
+            if( !ret )
+            {
+                llrpInitDarkFrameExtFileName( mlvObject, dfBytes.data() );
+                if( errorMessage[0] )
+                {
+                    BatchLogger::err( QStringLiteral("[BATCH] WARNING dark frame: %1\n")
+                                          .arg( QString(errorMessage) ) );
+                }
+            }
+            else
+            {
+                BatchLogger::err( QStringLiteral("[BATCH] WARNING dark frame rejected: %1\n")
+                                      .arg( QString(errorMessage) ) );
+                llrpFreeDarkFrameExtFileName( mlvObject );
+            }
+        }
+        else
+        {
+            llrpFreeDarkFrameExtFileName( mlvObject );
+        }
+
+        /* Set dark frame mode (0=off, 1=ext, 2=int).
+         * If ext/int requested but no dark frame available, force off. */
+        int dfMode = receipt->darkFrameEnabled();
+        if( dfMode == -1 )
+        {
+            /* Auto-detect: use internal dark frame if available */
+            if( llrpGetDarkFrameIntStatus( mlvObject ) )
+                dfMode = 2;
+            else
+                dfMode = 0;
+        }
+        if( dfMode > 0 && !llrpGetDarkFrameExtStatus( mlvObject )
+                       && !llrpGetDarkFrameIntStatus( mlvObject ) )
+        {
+            dfMode = 0;
+        }
+        llrpSetDarkFrameMode( mlvObject, dfMode );
+
+        /* Dark frame affects dual ISO correction — match GUI behavior */
+        if( mlvObject->llrawproc->diso_auto_correction > 0 )
+        {
+            mlvObject->llrawproc->diso_auto_correction =
+                -mlvObject->llrawproc->diso_auto_correction;
+            mlvObject->llrawproc->diso_black_delta = -1;
+        }
+        llrpResetBpmStatus( mlvObject );
+        llrpComputeStripesOn( mlvObject );
+    }
+
+    /* ---- Raw black / white levels ----
+     * -1 = use file defaults (do not override). */
+    if( receipt->rawWhite() != -1 )
+    {
+        int wl = receipt->rawWhite();
+        /* Clamp: white must be above black */
+        int bl = (receipt->rawBlack() != -1) ? (int)(receipt->rawBlack() / 10.0)
+                                             : getMlvBlackLevel( mlvObject );
+        if( wl <= bl + 1 ) wl = bl + 2;
+
+        setMlvWhiteLevel( mlvObject, wl );
+        processingSetWhiteLevel( processingObject, wl, getMlvBitdepth( mlvObject ) );
+        llrpResetFpmStatus( mlvObject );
+        llrpResetBpmStatus( mlvObject );
+    }
+
+    if( receipt->rawBlack() != -1 )
+    {
+        double rawBlack = receipt->rawBlack() / 10.0;
+        /* Clamp: black must be below white */
+        if( rawBlack >= getMlvWhiteLevel( mlvObject ) - 1 )
+            rawBlack = getMlvWhiteLevel( mlvObject ) - 2;
+
+        setMlvBlackLevel( mlvObject, rawBlack );
+        processingSetBlackLevel( processingObject, rawBlack, getMlvBitdepth( mlvObject ) );
+        llrpResetFpmStatus( mlvObject );
+        llrpResetBpmStatus( mlvObject );
+    }
+
+    /* Final cache reset — ensures all settings take effect on next frame read */
+    resetMlvCache( mlvObject );
+    resetMlvCachedFrame( mlvObject );
+}
+
+
+/* -----------------------------------------------------------------------
+ * printFingerprint()
+ *
+ * Reads ACTUAL runtime state from the mlvObject/processingObject and
+ * prints a structured line.  This proves settings reached the pipeline,
+ * not just the ReceiptSettings parser.
+ * ----------------------------------------------------------------------- */
+
+void ReceiptApplier::printFingerprint(mlvObject_t *mlvObject,
+                                       processingObject_t * /* processingObject */)
+{
+    llrawprocObject_t *llr = mlvObject->llrawproc;
+
+    BatchLogger::out( QStringLiteral(
+        "[BATCH] FINGERPRINT"
+        " fixRaw=%1"
+        " focusPixels=%2"
+        " fpiMethod=%3"
+        " badPixels=%4"
+        " bpsMethod=%5"
+        " bpiMethod=%6"
+        " chromaSmooth=%7"
+        " patternNoise=%8"
+        " verticalStripes=%9"
+        " deflickerTarget=%10"
+        " dualIso=%11"
+        " disoValidity=%12"
+        " disoPattern=%13"
+        " disoAutoCorr=%14"
+        " disoEvCorr=%15"
+        " disoBlackDelta=%16"
+        " disoAveraging=%17"
+        " disoAliasMap=%18"
+        " disoFrBlending=%19"
+        " darkFrame=%20"
+        " rawBlack=%21"
+        " rawWhite=%22"
+        "\n")
+        .arg( llr->fix_raw )
+        .arg( llr->focus_pixels )
+        .arg( llr->fpi_method )
+        .arg( llr->bad_pixels )
+        .arg( llr->bps_method )
+        .arg( llr->bpi_method )
+        .arg( llr->chroma_smooth )
+        .arg( llr->pattern_noise )
+        .arg( llr->vertical_stripes )
+        .arg( llr->deflicker_target )
+        .arg( llr->dual_iso )
+        .arg( llr->diso_validity )
+        .arg( llr->diso_pattern )
+        .arg( llr->diso_auto_correction )
+        .arg( llr->diso_ev_correction, 0, 'f', 4 )
+        .arg( llr->diso_black_delta )
+        .arg( llr->diso_averaging )
+        .arg( llr->diso_alias_map )
+        .arg( llr->diso_frblending )
+        .arg( llr->dark_frame )
+        .arg( getMlvBlackLevel( mlvObject ) )
+        .arg( getMlvWhiteLevel( mlvObject ) )
+    );
+}

--- a/src/batch/ReceiptApplier.h
+++ b/src/batch/ReceiptApplier.h
@@ -1,0 +1,36 @@
+#ifndef RECEIPTAPPLIER_H
+#define RECEIPTAPPLIER_H
+
+/* C API types — mlvObject_t and processingObject_t are anonymous typedefs,
+ * so we must include the full header (forward declaration won't work). */
+#include "../../src/mlv_include.h"
+
+class ReceiptSettings;
+
+/* Applies parsed ReceiptSettings to the runtime mlvObject_t / processingObject_t
+ * using the same C API calls the GUI's setSliders() triggers through its
+ * signal chain.  This is the standalone batch-mode equivalent.
+ *
+ * Also provides a FINGERPRINT printer that reads back the actual runtime
+ * state from the objects — proving settings reached the pipeline. */
+class ReceiptApplier
+{
+public:
+    /* Apply all CDNG-relevant receipt settings to the MLV pipeline.
+     * receipt is non-const because the GUI logic mutates certain fields
+     * (e.g. dualIsoForced, dualIso) during application. */
+    static void applyToMlv(ReceiptSettings *receipt,
+                            mlvObject_t *mlvObject,
+                            processingObject_t *processingObject);
+
+    /* Read back actual runtime state from mlvObject/processingObject and
+     * print a structured [BATCH] FINGERPRINT line via BatchLogger.
+     * Can be called even when no receipt was loaded (prints defaults). */
+    static void printFingerprint(mlvObject_t *mlvObject,
+                                 processingObject_t *processingObject);
+
+private:
+    ReceiptApplier() = delete; /* Pure static — no instances */
+};
+
+#endif // RECEIPTAPPLIER_H

--- a/src/batch/ReceiptLoader.cpp
+++ b/src/batch/ReceiptLoader.cpp
@@ -1,0 +1,726 @@
+#include "ReceiptLoader.h"
+#include "BatchLogger.h"
+
+#include "../../platform/qt/ReceiptSettings.h"
+
+#include <QFile>
+#include <QFileInfo>
+#include <QXmlStreamReader>
+
+/* These constants are defined locally in MainWindow.cpp for receipt
+ * version < 2 compatibility scaling.  Duplicated here to avoid
+ * pulling in MainWindow.h for three trivial numbers. */
+#define FACTOR_DS       22.5
+#define FACTOR_LS       11.2
+#define FACTOR_LIGHTEN  0.6
+
+/* DISO_FORCED comes from the llrawproc C API enum */
+extern "C" {
+#include "../../src/mlv/llrawproc/llrawproc.h"
+}
+
+/* PROFILE_* and GAMUT_* constants from processing API */
+extern "C" {
+#include "../../src/processing/raw_processing.h"
+}
+
+/* ------------------------------------------------------------------ */
+
+bool ReceiptLoader::loadFromFile(const QString &receiptPath,
+                                 ReceiptSettings *receipt,
+                                 QString *errorMsg)
+{
+    QFileInfo fi(receiptPath);
+    if( !fi.exists() || !fi.isFile() )
+    {
+        if( errorMsg )
+            *errorMsg = QStringLiteral("Receipt file not found: %1").arg(receiptPath);
+        return false;
+    }
+
+    QFile file(receiptPath);
+    if( !file.open(QIODevice::ReadOnly | QFile::Text) )
+    {
+        if( errorMsg )
+            *errorMsg = QStringLiteral("Cannot open receipt file: %1").arg(receiptPath);
+        return false;
+    }
+
+    QXmlStreamReader Rxml;
+    Rxml.setDevice(&file);
+
+    bool foundReceipt = false;
+    int versionReceipt = 0;
+
+    /* Scan for the <receipt> root element — same logic as
+     * MainWindow::on_actionImportReceipt_triggered() */
+    while( !Rxml.atEnd() )
+    {
+        Rxml.readNext();
+        if( Rxml.isStartElement() && Rxml.name() == QString("receipt") )
+        {
+            if( Rxml.attributes().size() != 0 )
+                versionReceipt = Rxml.attributes().at(0).value().toInt();
+            parseXmlElements( &Rxml, receipt, versionReceipt );
+            foundReceipt = true;
+            break;
+        }
+    }
+
+    if( Rxml.hasError() )
+    {
+        if( errorMsg )
+            *errorMsg = QStringLiteral("XML parse error in %1: %2")
+                            .arg(receiptPath, Rxml.errorString());
+        file.close();
+        return false;
+    }
+
+    file.close();
+
+    if( !foundReceipt )
+    {
+        if( errorMsg )
+            *errorMsg = QStringLiteral("No <receipt> element found in: %1").arg(receiptPath);
+        return false;
+    }
+
+    receipt->setLoaded();
+    return true;
+}
+
+/* ------------------------------------------------------------------ */
+
+void ReceiptLoader::printCdngSettings(const ReceiptSettings *receipt)
+{
+    /* Cast away const — ReceiptSettings getters are non-const (upstream
+     * design).  We only call getters here, so this is safe. */
+    ReceiptSettings *r = const_cast<ReceiptSettings *>(receipt);
+
+    BatchLogger::out(QStringLiteral("[BATCH] RECEIPT settings (CDNG-relevant):\n"));
+
+    /* --- Raw fixes --- */
+    BatchLogger::out(QStringLiteral("[BATCH]   rawFixesEnabled   = %1\n")
+                .arg( r->rawFixesEnabled() ? QStringLiteral("true")
+                                           : QStringLiteral("false") ));
+    BatchLogger::out(QStringLiteral("[BATCH]   verticalStripes   = %1\n").arg( r->verticalStripes() ));
+    BatchLogger::out(QStringLiteral("[BATCH]   focusPixels       = %1\n").arg( r->focusPixels() ));
+    BatchLogger::out(QStringLiteral("[BATCH]   fpiMethod         = %1\n").arg( r->fpiMethod() ));
+    BatchLogger::out(QStringLiteral("[BATCH]   badPixels         = %1\n").arg( r->badPixels() ));
+    BatchLogger::out(QStringLiteral("[BATCH]   bpsMethod         = %1\n").arg( r->bpsMethod() ));
+    BatchLogger::out(QStringLiteral("[BATCH]   bpiMethod         = %1\n").arg( r->bpiMethod() ));
+    BatchLogger::out(QStringLiteral("[BATCH]   chromaSmooth      = %1\n").arg( r->chromaSmooth() ));
+    BatchLogger::out(QStringLiteral("[BATCH]   patternNoise      = %1\n").arg( r->patternNoise() ));
+    BatchLogger::out(QStringLiteral("[BATCH]   deflickerTarget   = %1\n").arg( r->deflickerTarget() ));
+
+    /* --- Dual ISO --- */
+    BatchLogger::out(QStringLiteral("[BATCH]   dualIso           = %1\n").arg( r->dualIso() ));
+    BatchLogger::out(QStringLiteral("[BATCH]   dualIsoForced     = %1\n").arg( r->dualIsoForced() ));
+    BatchLogger::out(QStringLiteral("[BATCH]   dualIsoPattern    = %1\n").arg( r->dualIsoPattern() ));
+    BatchLogger::out(QStringLiteral("[BATCH]   dualIsoEvCorrection = %1\n").arg( r->dualIsoEvCorrection() ));
+    BatchLogger::out(QStringLiteral("[BATCH]   dualIsoBlackDelta = %1\n").arg( r->dualIsoBlackDelta() ));
+    BatchLogger::out(QStringLiteral("[BATCH]   dualIsoInterpolation = %1\n").arg( r->dualIsoInterpolation() ));
+    BatchLogger::out(QStringLiteral("[BATCH]   dualIsoAliasMap   = %1\n").arg( r->dualIsoAliasMap() ));
+    BatchLogger::out(QStringLiteral("[BATCH]   dualIsoFrBlending = %1\n").arg( r->dualIsoFrBlending() ));
+    BatchLogger::out(QStringLiteral("[BATCH]   dualIsoWhite      = %1\n").arg( r->dualIsoWhite() ));
+    BatchLogger::out(QStringLiteral("[BATCH]   dualIsoBlack      = %1\n").arg( r->dualIsoBlack() ));
+
+    /* --- Dark frame --- */
+    BatchLogger::out(QStringLiteral("[BATCH]   darkFrameEnabled  = %1\n").arg( r->darkFrameEnabled() ));
+    BatchLogger::out(QStringLiteral("[BATCH]   darkFrameFileName = %1\n").arg( r->darkFrameFileName() ));
+
+    /* --- Raw black/white levels --- */
+    BatchLogger::out(QStringLiteral("[BATCH]   rawBlack          = %1\n").arg( r->rawBlack() ));
+    BatchLogger::out(QStringLiteral("[BATCH]   rawWhite          = %1\n").arg( r->rawWhite() ));
+
+    /* --- Cut in/out --- */
+    BatchLogger::out(QStringLiteral("[BATCH]   cutIn             = %1\n").arg( r->cutIn() ));
+    BatchLogger::out(QStringLiteral("[BATCH]   cutOut            = %1\n").arg( r->cutOut() ));
+
+    /* --- Stretch / orientation --- */
+    BatchLogger::out(QStringLiteral("[BATCH]   stretchFactorX    = %1\n").arg( r->stretchFactorX(), 0, 'f', 4 ));
+    BatchLogger::out(QStringLiteral("[BATCH]   stretchFactorY    = %1\n").arg( r->stretchFactorY(), 0, 'f', 4 ));
+    BatchLogger::out(QStringLiteral("[BATCH]   upsideDown        = %1\n")
+                .arg( r->upsideDown() ? QStringLiteral("true")
+                                      : QStringLiteral("false") ));
+}
+
+/* ------------------------------------------------------------------ */
+/* parseXmlElements — verbatim copy of
+ * MainWindow::readXmlElementsFromFile() with no MainWindow dependency.
+ * Parses ALL tags so ReceiptSettings is fully populated.
+ * Version compatibility (v0-v4) logic preserved exactly. */
+
+void ReceiptLoader::parseXmlElements(QXmlStreamReader *Rxml,
+                                     ReceiptSettings *receipt,
+                                     int version)
+{
+    /* Compatibility defaults for old receipts (same as MainWindow) */
+    receipt->setCamMatrixUsed( 0 );
+    receipt->setDualIsoForced( DISO_FORCED );
+    receipt->setDualIsoAutoCorrected( 1 );
+    receipt->setDualIsoPattern( 0 );
+    receipt->setDualIsoEvCorrection( 1 );
+    receipt->setDualIsoBlackDelta( -1 );
+
+    while( !Rxml->atEnd() && !Rxml->isEndElement() )
+    {
+        Rxml->readNext();
+
+        if( Rxml->isStartElement() && Rxml->name() == QString( "exposure" ) )
+        {
+            receipt->setExposure( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "contrast" ) )
+        {
+            receipt->setContrast( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "pivot" ) )
+        {
+            receipt->setPivot( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "temperature" ) )
+        {
+            receipt->setTemperature( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "tint" ) )
+        {
+            receipt->setTint( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "clarity" ) )
+        {
+            receipt->setClarity( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "vibrance" ) )
+        {
+            receipt->setVibrance( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "saturation" ) )
+        {
+            if( version < 2 ) receipt->setSaturation( ( Rxml->readElementText().toInt() * 2.0 ) - 100.0 );
+            else receipt->setSaturation( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "ls" ) )
+        {
+            if( version < 2 ) receipt->setLs( Rxml->readElementText().toInt() * 10.0 / FACTOR_LS );
+            else receipt->setLs( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "lr" ) )
+        {
+            receipt->setLr( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "ds" ) )
+        {
+            if( version < 2 ) receipt->setDs( Rxml->readElementText().toInt() * 10.0 / FACTOR_DS );
+            else receipt->setDs( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "dr" ) )
+        {
+            receipt->setDr( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "lightening" ) )
+        {
+            if( version < 2 ) receipt->setLightening( Rxml->readElementText().toInt() / FACTOR_LIGHTEN );
+            else receipt->setLightening( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "shadows" ) )
+        {
+            receipt->setShadows( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "highlights" ) )
+        {
+            receipt->setHighlights( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "gradationCurve" ) )
+        {
+            receipt->setGradationCurve( Rxml->readElementText() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "hueVsHue" ) )
+        {
+            receipt->setHueVsHue( Rxml->readElementText() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "hueVsSaturation" ) )
+        {
+            receipt->setHueVsSaturation( Rxml->readElementText() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "hueVsLuminance" ) )
+        {
+            receipt->setHueVsLuminance( Rxml->readElementText() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "lumaVsSaturation" ) )
+        {
+            receipt->setLumaVsSaturation( Rxml->readElementText() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "gradientEnabled" ) )
+        {
+            receipt->setGradientEnabled( (bool)Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "gradientExposure" ) )
+        {
+            receipt->setGradientExposure( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "gradientContrast" ) )
+        {
+            receipt->setGradientContrast( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "gradientStartX" ) )
+        {
+            receipt->setGradientStartX( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "gradientStartY" ) )
+        {
+            receipt->setGradientStartY( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "gradientLength" ) )
+        {
+            receipt->setGradientLength( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "gradientAngle" ) )
+        {
+            receipt->setGradientAngle( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "sharpen" ) )
+        {
+            receipt->setSharpen( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "sharpenMasking" ) )
+        {
+            receipt->setShMasking( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "chromaBlur" ) )
+        {
+            receipt->setChromaBlur( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "highlightReconstruction" ) )
+        {
+            receipt->setHighlightReconstruction( (bool)Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "camMatrixUsed" ) )
+        {
+            receipt->setCamMatrixUsed( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "chromaSeparation" ) )
+        {
+            receipt->setChromaSeparation( (bool)Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "profile" ) )
+        {
+            uint8_t profile = (uint8_t)Rxml->readElementText().toUInt();
+            if( version < 2 && profile > 1 ) receipt->setProfile( profile + 2 );
+            else if( version == 2 )
+            {
+                receipt->setProfile( profile + 1 );
+                receipt->setGamut( GAMUT_Rec709 );
+                if( ( profile != PROFILE_ALEXA_LOG )
+                 && ( profile != PROFILE_CINEON_LOG )
+                 && ( profile != PROFILE_SONY_LOG_3 )
+                 && ( profile != PROFILE_SRGB )
+                 && ( profile != PROFILE_REC709 )
+                 && ( profile != PROFILE_DWG_INT ) )
+                {
+                    receipt->setAllowCreativeAdjustments( true );
+                }
+                else
+                {
+                    receipt->setAllowCreativeAdjustments( false );
+                }
+                switch( profile )
+                {
+                case PROFILE_STANDARD:
+                case PROFILE_TONEMAPPED:
+                    receipt->setGamma( 315 );
+                    break;
+                case PROFILE_FILM:
+                    receipt->setGamma( 346 );
+                    break;
+                default:
+                    receipt->setGamma( 100 );
+                    break;
+                }
+            }
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "tonemap" ) )
+        {
+            receipt->setTonemap( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "transferFunction" ) )
+        {
+            receipt->setTransferFunction( Rxml->readElementText() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "gamut" ) )
+        {
+            receipt->setGamut( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "gamma" ) )
+        {
+            receipt->setGamma( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "allowCreativeAdjustments" ) )
+        {
+            receipt->setAllowCreativeAdjustments( (bool)Rxml->readElementText().toInt() );
+            if( version == 2 )
+            {
+                int profile = receipt->profile();
+                if( ( profile != PROFILE_ALEXA_LOG )
+                 && ( profile != PROFILE_CINEON_LOG )
+                 && ( profile != PROFILE_SONY_LOG_3 )
+                 && ( profile != PROFILE_SRGB )
+                 && ( profile != PROFILE_REC709 )
+                 && ( profile != PROFILE_DWG_INT ) )
+                {
+                    receipt->setAllowCreativeAdjustments( true );
+                }
+            }
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "exrMode" ) )
+        {
+            receipt->setExrMode( (bool)Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "agx" ) )
+        {
+            receipt->setAgx( (bool)Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "denoiserWindow" ) )
+        {
+            receipt->setDenoiserWindow( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "denoiserStrength" ) )
+        {
+            receipt->setDenoiserStrength( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "rbfDenoiserLuma" ) )
+        {
+            receipt->setRbfDenoiserLuma( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "rbfDenoiserChroma" ) )
+        {
+            receipt->setRbfDenoiserChroma( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "rbfDenoiserRange" ) )
+        {
+            receipt->setRbfDenoiserRange( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "grainStrength" ) )
+        {
+            receipt->setGrainStrength( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "grainLumaWeight" ) )
+        {
+            receipt->setGrainLumaWeight( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "rawFixesEnabled" ) )
+        {
+            receipt->setRawFixesEnabled( (bool)Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "verticalStripes" ) )
+        {
+            receipt->setVerticalStripes( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "focusPixels" ) )
+        {
+            receipt->setFocusPixels( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "fpiMethod" ) )
+        {
+            receipt->setFpiMethod( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "badPixels" ) )
+        {
+            receipt->setBadPixels( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "bpsMethod" ) )
+        {
+            receipt->setBpsMethod( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "bpiMethod" ) )
+        {
+            receipt->setBpiMethod( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "chromaSmooth" ) )
+        {
+            receipt->setChromaSmooth( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "patternNoise" ) )
+        {
+            receipt->setPatternNoise( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "deflickerTarget" ) )
+        {
+            receipt->setDeflickerTarget( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "dualIsoForced" ) )
+        {
+            receipt->setDualIsoForced( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "dualIso" ) )
+        {
+            receipt->setDualIso( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "dualIsoPattern" ) )
+        {
+            receipt->setDualIsoPattern( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "dualIsoEvCorrection" ) )
+        {
+            receipt->setDualIsoEvCorrection( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "dualIsoBlackDelta" ) )
+        {
+            receipt->setDualIsoBlackDelta( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "dualIsoInterpolation" ) )
+        {
+            receipt->setDualIsoInterpolation( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "dualIsoAliasMap" ) )
+        {
+            receipt->setDualIsoAliasMap( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "dualIsoFrBlending" ) )
+        {
+            receipt->setDualIsoFrBlending( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "dualIsoWhite" ) )
+        {
+            receipt->setDualIsoWhite( Rxml->readElementText().toUInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "dualIsoBlack" ) )
+        {
+            receipt->setDualIsoBlack( Rxml->readElementText().toUInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "darkFrameFileName" ) )
+        {
+            receipt->setDarkFrameFileName( Rxml->readElementText() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "darkFrameEnabled" ) )
+        {
+            receipt->setDarkFrameEnabled( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "rawBlack" ) )
+        {
+            if( version < 4 ) receipt->setRawBlack( Rxml->readElementText().toInt() * 10 );
+            else receipt->setRawBlack( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "rawWhite" ) )
+        {
+            receipt->setRawWhite( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "tone" ) )
+        {
+            receipt->setTone( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "toningStrength" ) )
+        {
+            receipt->setToningStrength( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "lutEnabled" ) )
+        {
+            receipt->setLutEnabled( (bool)Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "lutName" ) )
+        {
+            receipt->setLutName( Rxml->readElementText() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "lutStrength" ) )
+        {
+            receipt->setLutStrength( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "filterEnabled" ) )
+        {
+            receipt->setFilterEnabled( (bool)Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "filterIndex" ) )
+        {
+            receipt->setFilterIndex( Rxml->readElementText().toUInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "filterStrength" ) )
+        {
+            receipt->setFilterStrength( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "vignetteStrength" ) )
+        {
+            receipt->setVignetteStrength( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "vignetteRadius" ) )
+        {
+            receipt->setVignetteRadius( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "vignetteShape" ) )
+        {
+            receipt->setVignetteShape( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "caRed" ) )
+        {
+            receipt->setCaRed( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "caBlue" ) )
+        {
+            receipt->setCaBlue( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "caDesaturate" ) )
+        {
+            receipt->setCaDesaturate( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "caRadius" ) )
+        {
+            receipt->setCaRadius( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "stretchFactorX" ) )
+        {
+            receipt->setStretchFactorX( Rxml->readElementText().toDouble() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "stretchFactorY" ) )
+        {
+            receipt->setStretchFactorY( Rxml->readElementText().toDouble() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "upsideDown" ) )
+        {
+            receipt->setUpsideDown( (bool)Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "vidstabEnable" ) )
+        {
+            receipt->setVidstabEnabled( (bool)Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "vidstabStepsize" ) )
+        {
+            receipt->setVidstabStepsize( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "vidstabShakiness" ) )
+        {
+            receipt->setVidstabShakiness( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "vidstabAccuracy" ) )
+        {
+            receipt->setVidstabAccuracy( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "vidstabZoom" ) )
+        {
+            receipt->setVidstabZoom( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "vidstabSmoothing" ) )
+        {
+            receipt->setVidstabSmoothing( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "vidstabTripod" ) )
+        {
+            receipt->setVidstabTripod( (bool)Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "cutIn" ) )
+        {
+            receipt->setCutIn( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "cutOut" ) )
+        {
+            receipt->setCutOut( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() && Rxml->name() == QString( "debayer" ) )
+        {
+            receipt->setDebayer( Rxml->readElementText().toInt() );
+            Rxml->readNext();
+        }
+        else if( Rxml->isStartElement() ) /* future/unknown tags */
+        {
+            Rxml->readElementText();
+            Rxml->readNext();
+        }
+    }
+}

--- a/src/batch/ReceiptLoader.h
+++ b/src/batch/ReceiptLoader.h
@@ -1,0 +1,42 @@
+#ifndef RECEIPTLOADER_H
+#define RECEIPTLOADER_H
+
+#include <QString>
+
+class QXmlStreamReader;
+class ReceiptSettings;
+
+/* Standalone .marxml receipt parser for batch mode.
+ * Extracts XML parsing logic from MainWindow::readXmlElementsFromFile()
+ * without requiring a MainWindow instance.
+ *
+ * Phase 6A: parse and print only.
+ * Phase 6B (future): apply parsed settings to mlvObject_t. */
+class ReceiptLoader
+{
+public:
+    /* Parse a .marxml receipt file into a ReceiptSettings object.
+     * Returns true on success.  On failure, returns false and sets
+     * errorMsg to a human-readable description. */
+    static bool loadFromFile(const QString &receiptPath,
+                             ReceiptSettings *receipt,
+                             QString *errorMsg);
+
+    /* Print CDNG-relevant settings from the receipt via BatchLogger.
+     * Only prints fields that affect raw/CDNG export — skips color
+     * grading, LUT, filter, vignette, sharpening, CA, vidstab, etc. */
+    static void printCdngSettings(const ReceiptSettings *receipt);
+
+private:
+    ReceiptLoader() = delete; /* Pure static */
+
+    /* Internal XML element parser — copied from
+     * MainWindow::readXmlElementsFromFile() to avoid MainWindow
+     * dependency.  Parses ALL tags (not just CDNG-relevant ones)
+     * so that the ReceiptSettings object is fully populated. */
+    static void parseXmlElements(QXmlStreamReader *Rxml,
+                                 ReceiptSettings *receipt,
+                                 int version);
+};
+
+#endif // RECEIPTLOADER_H


### PR DESCRIPTION
## Summary
- Add `--batch` CLI mode for headless Cinema DNG sequence export
- Extract `exportCdngSequence()` as static helper from GUI export path
- Add `.marxml` receipt loading (`--receipt`, `--default-receipt`) with full pipeline application
- Add `--resume` flag for resumable exports (scans existing DNG output, skips completed clips)
- Structured `[BATCH]` log output for .NET orchestrator integration

## Commits
1. **Phase 1-2**: BatchContext, BatchPrompts stubs, CLI entry point with QCommandLineParser
2. **Phase 3-4**: CDNG export helper extraction + BatchRunner + full BatchPrompts dialog replacement
3. **BatchLogger**: `--log` file mirroring; fix `--help` on Windows/Qt
4. **Phase 6A**: ReceiptLoader for `.marxml` receipt parsing and `--receipt` CLI flag
5. **Phase 6B prep**: `--default-receipt` flag and auto-detect GUI default receipt
6. **Phase 6B**: ReceiptApplier — apply parsed settings to MLV pipeline (same C API as GUI)
7. **Resume**: `--resume` flag with video_index scan, three resume paths, no file deletion

## Test plan
- [ ] Fresh single-file export: `MLVApp.exe --batch -i clip.mlv -o outdir --skip-errors`
- [ ] Folder batch export with receipt: `--batch -i folder/ -o outdir -r settings.marxml`
- [ ] Resume already-complete clip: verify `[BATCH] RESUME already_complete`, 0 frames exported
- [ ] Resume partial export: verify cutIn advances, only remaining frames exported
- [ ] GUI mode still launches normally (no `--batch` flag)
- [ ] `--help` prints usage text without QMessageBox