### PR TITLE
Seek the "In" frame on clip load if exists

### DIFF
--- a/platform/qt/MainWindow.cpp
+++ b/platform/qt/MainWindow.cpp
@@ -1061,6 +1061,21 @@ int MainWindow::openMlv( QString fileName )
     //Cut In & Out
     initCutInOut( getMlvFrames( m_pMlvObject ) );
 
+    //Seek to the saved "In" frame. The receipt's default is cutIn == 1 (frame
+    //0), so a fresh clip with no In point set still opens at the first frame.
+    //A value > 1 means the user (or a saved session) explicitly set an In
+    //point, and we should jump there. Clamp to the slider's valid range so a
+    //stale cut-in from a longer clip cannot overshoot this one.
+    if( ACTIVE_RECEIPT->cutIn() > 1 )
+    {
+        int cutInFrame = (int)ACTIVE_RECEIPT->cutIn() - 1; // 0-based frame index
+        int sliderMax = ui->horizontalSliderPosition->maximum();
+        if( cutInFrame < 0 ) cutInFrame = 0;
+        if( cutInFrame > sliderMax ) cutInFrame = sliderMax;
+        ui->horizontalSliderPosition->setValue( cutInFrame );
+        m_frameChanged = true;
+    }
+
     //Raw black & white level
     initRawBlackAndWhite();
 

--- a/platform/qt/MainWindow.cpp
+++ b/platform/qt/MainWindow.cpp
@@ -1073,7 +1073,6 @@ int MainWindow::openMlv( QString fileName )
         if( cutInFrame < 0 ) cutInFrame = 0;
         if( cutInFrame > sliderMax ) cutInFrame = sliderMax;
         ui->horizontalSliderPosition->setValue( cutInFrame );
-        m_frameChanged = true;
     }
 
     //Raw black & white level


### PR DESCRIPTION
When an "In" frame is defined, load that frame directly when browsing clips.
Useful to notice when the "In" frame is set. Also to compare clips on specific frames, when jumping from one clip to another.